### PR TITLE
fix: Fixes from integration tests

### DIFF
--- a/selene-compilers/hugr_qis/rust/lib.rs
+++ b/selene-compilers/hugr_qis/rust/lib.rs
@@ -27,6 +27,7 @@ use std::rc::Rc;
 use std::vec::Vec;
 use std::{fs, str, vec};
 use tket2::extension::TKET2_EXTENSION;
+use tket2::extension::rotation::ROTATION_EXTENSION;
 use tket2::hugr::extension::{ExtensionRegistry, prelude};
 use tket2::hugr::std_extensions::arithmetic::{
     conversions, float_ops, float_types, int_ops, int_types,
@@ -34,6 +35,7 @@ use tket2::hugr::std_extensions::arithmetic::{
 use tket2::hugr::std_extensions::{collections, logic, ptr};
 use tket2::hugr::{self, llvm::inkwell};
 use tket2::hugr::{Hugr, HugrView, Node};
+use tket2::llvm::rotation::RotationCodegenExtension;
 use tket2_hseries::QSystemPass;
 use tket2_hseries::extension::{futures as qsystem_futures, qsystem, result as qsystem_result};
 pub use tket2_hseries::llvm::futures::FuturesCodegenExtension;
@@ -67,6 +69,7 @@ static REGISTRY: std::sync::LazyLock<ExtensionRegistry> = std::sync::LazyLock::n
         qsystem_futures::EXTENSION.to_owned(),
         qsystem_result::EXTENSION.to_owned(),
         qsystem::EXTENSION.to_owned(),
+        ROTATION_EXTENSION.to_owned(),
         TKET2_EXTENSION.to_owned(),
         tket2::extension::bool::BOOL_EXTENSION.to_owned(),
         tket2::extension::debug::DEBUG_EXTENSION.to_owned(),
@@ -144,9 +147,10 @@ fn codegen_extensions() -> CodegenExtsMap<'static, Hugr> {
         .add_extension(ArrayCodegenExtension::new(DefaultArrayCodegen))
         .add_default_static_array_extensions()
         .add_extension(FuturesCodegenExtension)
-        .add_extension(QSystemCodegenExtension::from(pcg))
+        .add_extension(QSystemCodegenExtension::from(pcg.clone()))
         .add_extension(RandomCodegenExtension)
         .add_extension(ResultsCodegenExtension)
+        .add_extension(RotationCodegenExtension::new(pcg.clone()))
         .add_extension(UtilsCodegenExtension)
         .add_extension(DebugCodegenExtension)
         .finish()

--- a/selene-sim/python/selene_sim/instance.py
+++ b/selene-sim/python/selene_sim/instance.py
@@ -85,17 +85,19 @@ class SeleneProcess:
         Get the environment variables for the process.
         """
         env = os.environ.copy()
+        additional_dirs = os.pathsep.join(str(p) for p in self.library_search_dirs)
+        path_name = ""
         match platform.system():
             case "Linux":
-                env["LD_LIBRARY_PATH"] = os.pathsep.join(
-                    str(p) for p in self.library_search_dirs
-                )
+                path_name = "LD_LIBRARY_PATH"
             case "Darwin":
-                env["DYLD_LIBRARY_PATH"] = os.pathsep.join(
-                    str(p) for p in self.library_search_dirs
-                )
+                path_name = "DYLD_LIBRARY_PATH"
             case "Windows":
-                env["PATH"] = os.pathsep.join(str(p) for p in self.library_search_dirs)
+                path_name = "PATH"
+        if path_name in env:
+            env[path_name] += os.pathsep + additional_dirs
+        else:
+            env[path_name] = additional_dirs
         return env
 
     def spawn(self):

--- a/selene-sim/python/selene_sim/result_handling/result_stream.py
+++ b/selene-sim/python/selene_sim/result_handling/result_stream.py
@@ -105,25 +105,25 @@ class ResultStream:
                         res.append(val)
                     case (self.UINT_TAG, sz):
                         vals = unpack(f"{sz}Q", self.get_chunk(sz * 8))
-                        res.append(vals)
+                        res.append(list(vals))
                     case (self.INT_TAG, 0):
                         (val,) = unpack("q", self.get_chunk(8))
                         res.append(val)
                     case (self.INT_TAG, sz):
                         vals = unpack(f"{sz}q", self.get_chunk(sz * 8))
-                        res.append(vals)
+                        res.append(list(vals))
                     case (self.FLT_TAG, 0):
                         (val,) = unpack("d", self.get_chunk(8))
                         res.append(val)
                     case (self.FLT_TAG, sz):
                         vals = unpack(f"{sz}d", self.get_chunk(sz * 8))
-                        res.append(vals)
+                        res.append(list(vals))
                     case (self.BIT_TAG, 0):
                         (val,) = unpack("B", self.get_chunk(1))
                         res.append(val)
                     case (self.BIT_TAG, sz):
                         vals = unpack(f"{sz}B", self.get_chunk(sz))
-                        res.append(vals)
+                        res.append(list(vals))
                     case (self.STR_TAG, sz):
                         val = self.get_chunk(sz).decode("utf-8")
                         res.append(val)


### PR DESCRIPTION
When migrating some existing guppy notebooks, I found some things that slipped through the net:

- Array result types should be coerced to lists upon parsing
- The rotation extension was missing from selene-hugr-qis-compiler
- The environment setup for spawned selene backend processes was overriding host paths, leading to missing libstdc++.so.6 errors in some contexts.

These are addressed in this PR.