### PR TITLE
fix: correct RZ gate in Stim

### DIFF
--- a/selene-ext/simulators/stim/rust/lib.rs
+++ b/selene-ext/simulators/stim/rust/lib.rs
@@ -123,9 +123,9 @@ impl SimulatorInterface for StimSimulator {
 
         match approx {
             ApproxAngle::Zero => (),
-            ApproxAngle::FracPi2 => self.simulator.sqrt_z_dag(q0_u32),
+            ApproxAngle::FracPi2 => self.simulator.sqrt_z(q0_u32),
             ApproxAngle::Pi => self.simulator.z(q0_u32),
-            ApproxAngle::Frac3Pi2 => self.simulator.sqrt_z(q0_u32),
+            ApproxAngle::Frac3Pi2 => self.simulator.sqrt_z_dag(q0_u32),
             ApproxAngle::NoSuitableApproximation => {
                 return Err(anyhow!(
                     "RZGate(q0={q0}, theta={theta}) is not representable in stabiliser form. Angles must be (approximate) multiples of pi/2 in order to use Stim."


### PR DESCRIPTION
This PR corrects the RZ rotation axis in the Stim plugin.

## Summary:
RZ was added as a gate in 0.2.0 series, as the RZ trick is now optional (through use of the SoftRZ runtime)

When adding it to the Stim plugin, the implementation was carried over from the RXY gate, which includes an RZ and an inverse RZ.

Unfortunately, the wrong one was copied, such that:
- $R_z(\frac{\pi}{2})$ was performing $\sqrt{Z}^\dagger$ rather than $\sqrt{Z}$ 
- $R_z(\frac{3\pi}{2})$ was performing $\sqrt{Z}$ rather than $\sqrt{Z}^\dagger$

in effect, inverting the Z rotation axis. Combined with the use of the correct Z rotation axis in other gates, this inversion had an observable impact.