### PR TITLE
feat: Storage cleanup utilities

### DIFF
--- a/selene-ext/simulators/quest/python/selene_quest_plugin/plugin.py
+++ b/selene-ext/simulators/quest/python/selene_quest_plugin/plugin.py
@@ -36,19 +36,32 @@ class QuestPlugin(Simulator):
     @staticmethod
     def extract_states_dict(
         results: Iterable[TaggedResult],
+        cleanup: bool = True,
     ) -> dict[str, SeleneQuestState]:
         """Extract state results from a shot result stream and return them as a
-        dictionary keyed by the state tag. Assumes tags are unique within the shot."""
-        return dict(QuestPlugin.extract_states(results))
+        dictionary keyed by the state tag. Assumes tags are unique within the shot.
+
+        By default, state files are removed after extraction, as they may take up
+        considerable storage space. Pass `cleanup=False` to keep the files.
+        """
+        return dict(QuestPlugin.extract_states(results, cleanup=cleanup))
 
     @staticmethod
     def extract_states(
         results: Iterable[TaggedResult],
+        cleanup: bool = True,
     ) -> Iterator[tuple[str, SeleneQuestState]]:
         """Extract state results from a shot result stream and return them as a
-        pair of (tag, state)."""
+        pair of (tag, state).
+
+        By default, state files are removed after extraction, as they may take up
+        considerable storage space. Pass `cleanup=False` to keep the state files.
+        """
         return (
-            (cast(str, state_tag), SeleneQuestState.parse_from_file(pth))
+            (
+                cast(str, state_tag),
+                SeleneQuestState.parse_from_file(pth, cleanup=cleanup),
+            )
             for tag, result in results
             if (state_tag := _state_tag(tag)) is not None
             and isinstance(result, str)

--- a/selene-ext/simulators/quest/python/selene_quest_plugin/state.py
+++ b/selene-ext/simulators/quest/python/selene_quest_plugin/state.py
@@ -216,7 +216,7 @@ class SeleneQuestState:
         )
 
     @staticmethod
-    def parse_from_file(filename: Path) -> "SeleneQuestState":
+    def parse_from_file(filename: Path, cleanup: bool = True) -> "SeleneQuestState":
         with open(filename, "rb") as f:
             magic = f.read(12)
             if magic != b"selene-quest":
@@ -232,4 +232,6 @@ class SeleneQuestState:
                 dtype=np.complex128,
                 count=state_size,
             )
-            return SeleneQuestState(state, total_qubits, specified_qubits)
+        if cleanup:
+            filename.unlink()
+        return SeleneQuestState(state, total_qubits, specified_qubits)

--- a/selene-sim/python/tests/test_cleanup.py
+++ b/selene-sim/python/tests/test_cleanup.py
@@ -1,0 +1,55 @@
+import pytest
+
+from guppylang import guppy
+from guppylang.std.quantum import discard, qubit
+
+from selene_sim.build import build
+from selene_sim import Quest
+
+
+def test_delete_files():
+    @guppy
+    def main() -> None:
+        q0 = qubit()
+        discard(q0)
+
+    runner = build(guppy.compile(main))
+    got = list(runner.run(Quest(), n_qubits=1))
+    runner.delete_files()
+    with pytest.raises(FileNotFoundError):
+        got = list(runner.run(Quest(), n_qubits=1))
+    assert not runner.root.exists()
+    # these are included in case we later decide to move files
+    # out of the build root. In this case we may have neglected
+    # to clean them up.
+    #
+    # If at the time this is intentional behaviour,
+    # then we can change this test.
+    assert not runner.executable.exists()
+    assert not runner.runs.exists()
+    assert not runner.artifacts.exists()
+
+
+def test_delete_run_directories():
+    @guppy
+    def main() -> None:
+        q0 = qubit()
+        discard(q0)
+
+    runner = build(guppy.compile(main))
+    got = list(runner.run(Quest(), n_qubits=1))
+    assert len(list(runner.runs.iterdir())) == 1
+
+    runner.delete_run_directories()
+    # we are only cleaning up runs, so everything needed
+    # for creating new runs should still work.
+    assert runner.root.exists()
+    assert runner.artifacts.exists()
+    assert runner.runs.exists()
+    assert len(list(runner.runs.iterdir())) == 0
+
+    # this should not fail
+    got = list(runner.run(Quest(), n_qubits=1))
+
+    # and we should see one run dir
+    assert len(list(runner.runs.iterdir())) == 1


### PR DESCRIPTION
Some users have requested cleanup of SeleneInstances after they have been run, or during a sequence of runs.

Other users have raised concerns about large statevector files being persisted in temporary storage after they have been read and delivered to the user.

This PR addresses these concerns:

- `SeleneInstance` gains a `delete_files()` method for removing its entire file tree
  - and gains a private _check_health function to ensure a friendly error if a subsequent simulation is run
- `SeleneInstance` also gains a `delete_run_directories()` method for cleaning files produced during sequences of runs.
  - this doesn't prevent further use of the selene instance.
- `QuestPlugin`'s `extract_states_dict` and `extract_states` methods now accept a `cleanup` parameter *which is True by default*.
  - if `cleanup`=True, files are removed after being read on the frontend.
  - this is now default behaviour, as keeping them around for later is a rare usecase.

Further thoughts:

With `delete_files`, we're kind of paving a way for further exposure of the SeleneInstance file tree, and so I'm considering supporting saving and loading. This should be trivial for single machine use, as we carry a manifest file, but I'd like to consider making them portable too - somehow.

Same goes for the run directories. Could we make more use out of them? They currently provide configuration files to the selene backend instance, and store artifacts (like state files). Maybe we could store the results in them by default too, so that we can revisit results of a run without performing the run again.