### PR TITLE
Feat: add support for aarch64 linux

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, macos-13, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-13, windows-latest]
     name: "Selene wheels (${{matrix.os}})"
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,10 +127,11 @@ exclude = [
 
 [tool.pytest.ini_options]
 # exclude external repos (e.g. stim)
-norecursedirs = ["selene-remove", "upstream", '*.egg', '.*', 'build', 'target', 'dist', 'venv']
+norecursedirs = ["upstream", '*.egg', '.*', 'build', 'target', 'dist', 'venv']
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
+manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64"
 build = "cp310-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux*"
 build-frontend = { name = "build[uv]", args = ["-C--profile=release"] }

--- a/selene-compilers/hugr_qis/pyproject.toml
+++ b/selene-compilers/hugr_qis/pyproject.toml
@@ -99,6 +99,7 @@ exclude = [
 build = "cp310-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux*"
 manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 test-requires = ["pytest", "pytest-snapshot", "git+https://github.com/cqcl/guppylang@090f920"]
 test-command = "pytest -vv {package}"
 
@@ -120,10 +121,17 @@ before-all = '''
             cp -r /host/tmp/ci-cache/hugr-qis/target {package}
         fi;
     fi;
-    dnf install https://azure.repo.almalinux.org/8.10/BaseOS/x86_64/os/Packages/libffi-devel-3.1-24.el8.x86_64.rpm -y;
-    curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz;
     mkdir -p /tmp/llvm;
-    tar xf clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz -C /tmp/llvm --strip-components=1;
+    if [ "$(uname -m)" = "x86_64" ];
+    then
+        dnf install https://azure.repo.almalinux.org/8.10/BaseOS/x86_64/os/Packages/libffi-devel-3.1-24.el8.x86_64.rpm -y;
+        curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz;
+        tar xf clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz -C /tmp/llvm --strip-components=1;
+    else
+        dnf install https://azure.repo.almalinux.org/almalinux/8.10/BaseOS/aarch64/os/Packages/libffi-devel-3.1-24.el8.aarch64.rpm -y;
+        curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz
+        tar xf clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz -C /tmp/llvm --strip-components=1;
+    fi;
 '''
 before-test = '''
     if ${CACHE_CARGO};

--- a/selene-compilers/hugr_qis/pyproject.toml
+++ b/selene-compilers/hugr_qis/pyproject.toml
@@ -129,7 +129,7 @@ before-all = '''
         tar xf clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz -C /tmp/llvm --strip-components=1;
     else
         dnf install https://azure.repo.almalinux.org/8.10/BaseOS/aarch64/os/Packages/libffi-devel-3.1-24.el8.aarch64.rpm -y;
-        dnf install ncurses-compat-libs -y;
+        dnf install ncurses-compat-libs ncurses-devel -y;
         curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz
         tar xf clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz -C /tmp/llvm --strip-components=1;
     fi;

--- a/selene-compilers/hugr_qis/pyproject.toml
+++ b/selene-compilers/hugr_qis/pyproject.toml
@@ -128,7 +128,8 @@ before-all = '''
         curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz;
         tar xf clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz -C /tmp/llvm --strip-components=1;
     else
-        dnf install https://azure.repo.almalinux.org/almalinux/8.10/BaseOS/aarch64/os/Packages/libffi-devel-3.1-24.el8.aarch64.rpm -y;
+        dnf install https://azure.repo.almalinux.org/8.10/BaseOS/aarch64/os/Packages/libffi-devel-3.1-24.el8.aarch64.rpm -y;
+        dnf install ncurses-compat-libs -y;
         curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz
         tar xf clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz -C /tmp/llvm --strip-components=1;
     fi;


### PR DESCRIPTION
As Selene is now open source, we should have access to ubuntu-24.04-arm runners.

Some changes to the cibuildwheel config are required to take into account differences between the build stages, particularly in selene-hugr-qis-compiler where we download an architecture-specific version of LLVM and libffi.

Closes #13.