### PR TITLE
chore: build validation testing

### DIFF
--- a/selene-core/python/selene_core/build_utils/utils.py
+++ b/selene-core/python/selene_core/build_utils/utils.py
@@ -105,7 +105,7 @@ def get_undefined_symbols_from_object(path: Path) -> list[str]:
 
     else:
         raise NotImplementedError(
-            f"Unsupported binary format for undefined symbol extraction: {path}"
+            f"Unsupported binary format {type(binary)} for undefined symbol extraction: {path}"
         )
 
 

--- a/selene-core/python/selene_core/build_utils/utils.py
+++ b/selene-core/python/selene_core/build_utils/utils.py
@@ -103,7 +103,25 @@ def get_undefined_symbols_from_object(path: Path) -> list[str]:
             if func.is_ordinal is False and func.name
         ]
 
+    elif binary is None:
+        # lief.parse() returned None, which means the binary format is not supported (yet),
+        # and we can't add support in Selene unless it does (or we find another approach).
+        raise RuntimeError(
+            f"The binary format of {path} is not yet supported by Lief, which is used by Selene for identifying undefined symbols."
+        )
+
     else:
+        # lief.parse() didn't return None, but it didn't return a binary type we can handle
+        # in selene yet. If we reach this error, it's possible that adding support is low-
+        # hanging fruit.
+        #
+        # An example is COFF. At the time of writing, lief does not support COFF input, so
+        # support for Windows lib files is currently diminished. However, lief has added
+        # basic COFF support on github, so the next pypi release should recognise COFF. When
+        # it does, we should be able to perform windows .lib file symbol extraction in Selene,
+        # which is a clear win.
+        #
+        # Until then, we wait.
         raise NotImplementedError(
             f"Unsupported binary format {type(binary)} for undefined symbol extraction: {path}"
         )

--- a/selene-core/python/selene_core/build_utils/utils.py
+++ b/selene-core/python/selene_core/build_utils/utils.py
@@ -82,7 +82,7 @@ def get_undefined_symbols_from_object(path: Path) -> list[str]:
     if isinstance(binary, lief.ELF.Binary):
         # ELF: undefined symbols have shndx == 0 (SHN_UNDEF)
         return [
-            s.name
+            str(s.name)
             for s in binary.symbols
             if s.shndx == 0 and s.value == 0  # Optional extra check
         ]
@@ -90,14 +90,14 @@ def get_undefined_symbols_from_object(path: Path) -> list[str]:
     elif isinstance(binary, lief.MachO.Binary):
         # Mach-O: undefined symbols have section_number == 0
         def demangle(name):
-            return name[1:] if name.startswith("_") else name
+            return str(name[1:] if name.startswith("_") else name)
 
         return [demangle(s.name) for s in binary.symbols if s.is_external]
 
     elif isinstance(binary, lief.PE.Binary):
         # PE doesn't have undefined symbols in the same sense, but we can check imports
         return [
-            entry.name
+            str(entry.name)
             for entry in binary.imports
             for func in entry.entries
             if func.is_ordinal is False and func.name

--- a/selene-core/python/selene_core/build_utils/utils.py
+++ b/selene-core/python/selene_core/build_utils/utils.py
@@ -69,7 +69,7 @@ def invoke_zig(*args, handle_triple=True, verbose=False) -> str:
     return handle.stdout
 
 
-def get_undefined_symbols_from_object(path: Path):
+def get_undefined_symbols_from_object(path: Path) -> list[str]:
     """
     Extract undefined symbols from an object file, with help from the `lief` library.
 
@@ -92,11 +92,7 @@ def get_undefined_symbols_from_object(path: Path):
         def demangle(name):
             return name[1:] if name.startswith("_") else name
 
-        return [
-            demangle(s.name)
-            for s in binary.symbols
-            if s.section_number == 0 and s.is_external  # type: ignore[attr-defined]
-        ]
+        return [demangle(s.name) for s in binary.symbols if s.is_external]
 
     elif isinstance(binary, lief.PE.Binary):
         # PE doesn't have undefined symbols in the same sense, but we can check imports

--- a/selene-sim/python/tests/test_build_validation.py
+++ b/selene-sim/python/tests/test_build_validation.py
@@ -1,0 +1,56 @@
+import pytest
+
+from guppylang import guppy
+from guppylang.std.quantum import discard, qubit
+
+from selene_sim.build import build
+from selene_sim import Quest
+
+
+@pytest.mark.parametrize(
+    "build_config",
+    [
+        {"name": "default", "kwargs": {}},
+        {"name": "llvm_ir", "kwargs": {"build_method": "via-llvm-ir"}},
+        {"name": "llvm_bc", "kwargs": {"build_method": "via-llvm-bitcode"}},
+    ],
+)
+def test_strict_builds(build_config, snapshot):
+    """
+    Selene sim builds are multi-step processes that
+    are described by a build graph, with artifacts
+    as nodes and build steps as edges.
+
+    Artifacts have 'kinds' that allow an incoming
+    artifact (e.g. passed to `selene_sim.build`)
+    to be matched against in order to establish the
+    build sequence.
+
+    Examples:
+      - An .ll file that is expected to depend on
+        specific function signatures.
+      - A .o file that depends on undefined functions
+        that we expect to be defined after linking.
+
+    By default, we only run artifact kind matching
+    on the user input - this is because checking can
+    be intensive (e.g. invoking system utilities to
+    identify undefined functions in an object file, or
+    parsing an LLVM file).
+
+    If we pass `strict=True` to `build`, then outputs of
+    steps are also checked against their expected kind.
+    Here we do that test to ensure that standard builds
+    and all of their intermediate artifacts conform to
+    expectations - and, importantly, to ensure that the
+    checks are working as intended.
+    """
+
+    @guppy
+    def main() -> None:
+        q0 = qubit()
+        discard(q0)
+
+    runner = build(guppy.compile(main), strict=True, **build_config["kwargs"])
+    got = list(runner.run(Quest(), n_qubits=1))
+    assert len(got) == 0

--- a/selene-sim/python/tests/test_build_validation.py
+++ b/selene-sim/python/tests/test_build_validation.py
@@ -1,4 +1,5 @@
 import pytest
+import platform
 
 from guppylang import guppy
 from guppylang.std.quantum import discard, qubit
@@ -7,6 +8,14 @@ from selene_sim.build import build
 from selene_sim import Quest
 
 
+@pytest.mark.xfail(
+    platform.system() == "Windows",
+    reason=(
+        "As Lief doesn't support COFF formats yet, we can't "
+        "detect undefined symbols in Windows lib files, and "
+        "thus can't run a strict build on Windows."
+    ),
+)
 @pytest.mark.parametrize(
     "build_config",
     [


### PR DESCRIPTION
## Background:
Selene sim builds are multi-step processes that are described by a build graph, with artifacts as nodes and build steps as edges.

Artifacts have 'kinds' that allow an incoming artifact (e.g. passed to `selene_sim.build`) to be matched against in order to establish the build sequence.

Examples:
- An .ll file that is expected to depend on specific function signatures.
- A .o file that depends on undefined functions that we expect to be defined after linking.

## This PR
By default, we only run artifact kind matching on the user input - this is because checking can be intensive (e.g. invoking system utilities to identify undefined functions in an object file, or parsing an LLVM file).

If we pass `strict=True` to `build`, then outputs of steps are also checked against their expected kind.

In this PR we add that test to ensure that standard builds and all of their intermediate artifacts conform to expectations - and, importantly, to ensure that the checks are working as intended.

## Why it is important

A working pipeline might look like:
```
hugr -> llvm bitcode -> object file -> selene build
```
and we expect that one could equally use the llvm bitcode as an input, or the object file as an input, and get the same selene build. This can only work if we guarantee that we are able to *detect* that the llvm bitcode is valid, or that the object file is valid.

The latter is particularly gnarly, because inspection of an object file (to ensure that it targets a specific API) in a cross platform manner is not straightforward, as object files and tooling differs on each platform. I expect to run into some CI failures with this PR, so it acts as a nice canary to detect where any issues lie today.

# Important Caveat

This isn't currently viable on Windows yet. We use Lief to analyse object files, and released Lief does not yet support COFF. COFF support has been [pushed](https://github.com/lief-project/LIEF/commit/84f963a7163467183dac2417e352e179d4fe0b84) but not yet released on pypi. I'm in no rush for it just yet so I'm happy to wait and update Windows support when it lands.