### PR TITLE
chore: Update tket2 to v0.12.3, tket2-hseries to v0.16.1

### DIFF
--- a/selene-compilers/hugr_qis/Cargo.lock
+++ b/selene-compilers/hugr_qis/Cargo.lock
@@ -1727,6 +1727,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,16 +1813,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.10.0",
- "schemars",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1820,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2031,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "tket2"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2520be9aff4e51f1a31298e8cccd61dcf54a344b70cbc907fbae0bc9ce83ca"
+checksum = "9d3311584b181f9dc6ea89d153830f3a154d1b619c4d7ae19eeb57589c780f99"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2068,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "tket2-hseries"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7299dc8d3583e6e8d2c1a737db18bbb65d0fed3b0e0f476042e88b3914cfd50"
+checksum = "dd9d902e681d5a463ce0cc1904b91cff632ea0f6b80d3fccfe4f8fa297f8d9cd"
 dependencies = [
  "anyhow",
  "clap",

--- a/selene-compilers/hugr_qis/Cargo.toml
+++ b/selene-compilers/hugr_qis/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0"
-tket2 = "0.12.1"
-tket2-hseries = { version = "0.16.0", features = ["llvm"] }
+tket2 = "0.12.3"
+tket2-hseries = { version = "0.16.1", features = ["llvm"] }
 pyo3 = { version = "0.24", features = ["abi3-py310", "anyhow"] }
 tracing = "0.1"
 itertools = "0.14.0"

--- a/selene-compilers/hugr_qis/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/aarch64-apple-darwin/measure_array_aarch64-apple-darwin
+++ b/selene-compilers/hugr_qis/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/aarch64-apple-darwin/measure_array_aarch64-apple-darwin
@@ -826,16 +826,16 @@ cond_169_case_1:                                  ; preds = %cond_194_case_1
   br label %cond_exit_194
 
 cond_exit_194:                                    ; preds = %cond_194_case_1, %cond_169_case_1, %alloca_block
-  ret {} zeroinitializer
+  ret {} undef
 }
-
-declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind readnone willreturn
 define { i1, { i1, i64, i1 } } @"__hugr__.$array.__comprehension.init.6$$t(bool).367"() local_unnamed_addr #0 {
 alloca_block:
   ret { i1, { i1, i64, i1 } } { i1 false, { i1, i64, i1 } poison }
 }
+
+declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 ; Function Attrs: noreturn
 declare void @panic(i32, i8*) local_unnamed_addr #1

--- a/selene-compilers/hugr_qis/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-apple-darwin/measure_array_x86_64-apple-darwin
+++ b/selene-compilers/hugr_qis/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-apple-darwin/measure_array_x86_64-apple-darwin
@@ -826,16 +826,16 @@ cond_169_case_1:                                  ; preds = %cond_194_case_1
   br label %cond_exit_194
 
 cond_exit_194:                                    ; preds = %cond_194_case_1, %cond_169_case_1, %alloca_block
-  ret {} zeroinitializer
+  ret {} undef
 }
-
-declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind readnone willreturn
 define { i1, { i1, i64, i1 } } @"__hugr__.$array.__comprehension.init.6$$t(bool).367"() local_unnamed_addr #0 {
 alloca_block:
   ret { i1, { i1, i64, i1 } } { i1 false, { i1, i64, i1 } poison }
 }
+
+declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 ; Function Attrs: noreturn
 declare void @panic(i32, i8*) local_unnamed_addr #1

--- a/selene-compilers/hugr_qis/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-unknown-linux-gnu/measure_array_x86_64-unknown-linux-gnu
+++ b/selene-compilers/hugr_qis/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-unknown-linux-gnu/measure_array_x86_64-unknown-linux-gnu
@@ -826,16 +826,16 @@ cond_169_case_1:                                  ; preds = %cond_194_case_1
   br label %cond_exit_194
 
 cond_exit_194:                                    ; preds = %cond_194_case_1, %cond_169_case_1, %alloca_block
-  ret {} zeroinitializer
+  ret {} undef
 }
-
-declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind readnone willreturn
 define { i1, { i1, i64, i1 } } @"__hugr__.$array.__comprehension.init.6$$t(bool).367"() local_unnamed_addr #0 {
 alloca_block:
   ret { i1, { i1, i64, i1 } } { i1 false, { i1, i64, i1 } poison }
 }
+
+declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 ; Function Attrs: noreturn
 declare void @panic(i32, i8*) local_unnamed_addr #1

--- a/selene-compilers/hugr_qis/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-windows-msvc/measure_array_x86_64-windows-msvc
+++ b/selene-compilers/hugr_qis/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-windows-msvc/measure_array_x86_64-windows-msvc
@@ -826,16 +826,16 @@ cond_169_case_1:                                  ; preds = %cond_194_case_1
   br label %cond_exit_194
 
 cond_exit_194:                                    ; preds = %cond_194_case_1, %cond_169_case_1, %alloca_block
-  ret {} zeroinitializer
+  ret {} undef
 }
-
-declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind readnone willreturn
 define { i1, { i1, i64, i1 } } @"__hugr__.$array.__comprehension.init.6$$t(bool).367"() local_unnamed_addr #0 {
 alloca_block:
   ret { i1, { i1, i64, i1 } } { i1 false, { i1, i64, i1 } poison }
 }
+
+declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 ; Function Attrs: noreturn
 declare void @panic(i32, i8*) local_unnamed_addr #1


### PR DESCRIPTION
A timely dependency update to sneak in before 0.2.0rc1 release.