### PR TITLE
fix: bitcode file detection + selene-core networkx dependency

### DIFF
--- a/selene-core/pyproject.toml
+++ b/selene-core/pyproject.toml
@@ -5,6 +5,9 @@ requires-python = ">=3.10"
 description = "The core interop library for Selene python interfaces"
 readme = "python/selene_core/README.md"
 
+[dependencies]
+networkx = "~=3.0.0"
+
 [project.urls]
 homepage = "https://github.com/CQCL/selene/selene-core"
 repository = "https://github.com/CQCL/selene/selene-core"

--- a/selene-core/python/selene_core/build_utils/builtins/helios.py
+++ b/selene-core/python/selene_core/build_utils/builtins/helios.py
@@ -26,7 +26,7 @@ class HeliosLLVMIRStringKind(ArtifactKind):
         if not isinstance(resource, str):
             return False
         undefined_symbols = get_undefined_symbols_from_llvm_ir_string(resource)
-        return any(s in undefined_symbols for s in ("teardown", "setup"))
+        return "teardown" in undefined_symbols
 
 
 class HeliosLLVMIRFileKind(ArtifactKind):
@@ -39,7 +39,7 @@ class HeliosLLVMIRFileKind(ArtifactKind):
         if resource.suffix != ".ll":
             return False
         undefined_symbols = get_undefined_symbols_from_llvm_ir_file(resource)
-        return any(s in undefined_symbols for s in ("teardown", "setup"))
+        return "teardown" in undefined_symbols
 
 
 class HeliosLLVMBitcodeStringKind(ArtifactKind):
@@ -53,11 +53,13 @@ class HeliosLLVMBitcodeStringKind(ArtifactKind):
 class HeliosLLVMBitcodeFileKind(ArtifactKind):
     @classmethod
     def matches(cls, resource: Any) -> bool:
-        return (
-            isinstance(resource, Path)
-            and resource.suffixes == [".helios", ".bc"]
-            and b"teardown" in resource.read_bytes()
-        )
+        if not isinstance(resource, Path):
+            return False
+        if not resource.is_file():
+            return False
+        if resource.suffix != ".bc":
+            return False
+        return b"teardown" in resource.read_bytes()
 
 
 class HeliosObjectFileKind(ArtifactKind):


### PR DESCRIPTION
When testing with other parts of the software stack, I found that:
- LLVM bitcode wasn't being accepted, as I'd mistakenly enforced a ".helios.bc" suffix requirement from an earlier build system design
- selene-core wasn't declaring its networkx dependency
  - it uses networkx to plan builds as a shortest path from the input 'kind' to the selene executable.
  
This PR fixes these issues.