### PR TITLE
build: relax typing-extensions constraint

### DIFF
--- a/selene-core/pyproject.toml
+++ b/selene-core/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "networkx~=3.4",
   "pyyaml~=6.0",
   "pydot>=4.0.0",
-  "typing_extensions~=4.14",
+  "typing_extensions>=4",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1262,7 +1262,7 @@ requires-dist = [
     { name = "networkx", specifier = "~=3.4" },
     { name = "pydot", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "typing-extensions", specifier = "~=4.14" },
+    { name = "typing-extensions", specifier = ">=4" },
 ]
 
 [[package]]


### PR DESCRIPTION
It was too strict as hugr required `~=4.12`.