### PR TITLE
chore: Add jfrog upload

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -17,7 +17,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_NET_GIT_FETCH_WITH_CLI: true
   CACHE_CARGO: true
 jobs:
   build_selene_core:
@@ -294,17 +293,29 @@ jobs:
         with:
           path: wheelhouse
           merge-multiple: true
+
       - name: GH Release
         uses: softprops/action-gh-release@v2
         with:
           files: wheelhouse/*.whl
           generate_release_notes: true
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+
       - name: Install twine
         run: python -m pip install twine
+
+      - name: Upload to jfrog
+        run: |
+          twine upload --verbose --non-interactive wheelhouse/*.whl
+        env:
+          TWINE_REPOSITORY_URL: ${{ secrets.JFROG_URL }}
+          TWINE_USERNAME: ${{ secrets.JFROG_USER }}
+          TWINE_PASSWORD: ${{ secrets.JFROG_TOKEN }}
+
       - name: Upload to pypi
         run: |
           twine upload --verbose --non-interactive wheelhouse/*.whl

--- a/devenv.nix
+++ b/devenv.nix
@@ -20,7 +20,6 @@
     '';
 
     env = {
-      CARGO_NET_GIT_FETCH_WITH_CLI = "true";
       LIBCLANG_PATH = "${pkgs.libclang.lib}";
       LLVM_SYS_140_PREFIX = "${pkgs.llvmPackages_14.libllvm.dev}";
     };


### PR DESCRIPTION
This serves two purposes.

1. it removes a conflict between stale artifactory wheels and more recent public pypi wheels.
2. conflicts in wheel versions can be caught before hitting pypi.
  - This is particularly handy because we are uploading multiple wheels.
  - Say a conflict is found on the second wheel during a pypi upload:
    - the first one is already uploaded
    - it cannot be amended
    - we require an artificial version bump to keep it updated
  - In a jfrog upload, the conflict can be noticed and corrected in one sweep before anything hits pypi, avoiding conflicts for open source users.

Drive by: remove CARGO_NET_FETCH_WITH_CLI, as we do not require authentication for fetching dependencies.