### PR TITLE
fix: Explicitly interpret user strings' length byte as unsigned

### DIFF
--- a/selene-ext/interfaces/helios_qis/c/src/interface.c
+++ b/selene-ext/interfaces/helios_qis/c/src/interface.c
@@ -93,7 +93,9 @@ uint64_t unwrap_future(struct selene_future_result_t result){
     return result.reference;
 }
 struct selene_string_t parse_cl_string(char const* str) {
-    return (struct selene_string_t){str+1, str[0], false};
+    uint8_t length = str[0];
+    char const* contents = str + 1;
+    return (struct selene_string_t){contents, length, false};
 }
 struct selene_string_t parse_c_string(char const* str) {
     if (str == 0) {


### PR DESCRIPTION
Strings from user programs enter the primary interface in the form [length][contents].

They are currently being promoted directly from (signed) char to u64, thus underflowing for lengths over 127. This fix explicitly interprets the string length as a u8 before the promotion takes place.