### PR TITLE
feat: random_advance

### DIFF
--- a/selene-ext/interfaces/helios_qis/c/src/interface.c
+++ b/selene-ext/interfaces/helios_qis/c/src/interface.c
@@ -323,6 +323,11 @@ void random_seed(uint64_t seed) {
     unwrap(selene_random_seed(selene_instance, seed));
     DIAGNOSTIC("   [done]\n");
 }
+void random_advance(uint64_t delta) {
+    DIAGNOSTIC("random_advance(%" PRIu64 ")\n", delta);
+    unwrap(selene_random_advance(selene_instance, delta));
+    DIAGNOSTIC("   [done]\n");
+}
 uint32_t random_int() {
     DIAGNOSTIC("random_int()\n");
     uint32_t result = unwrap(selene_random_u32(selene_instance));

--- a/selene-sim/c/include/selene/selene.h
+++ b/selene-sim/c/include/selene/selene.h
@@ -149,6 +149,16 @@ struct selene_bool_result_t selene_qubit_measure(struct SeleneInstance *instance
 struct selene_void_result_t selene_qubit_reset(struct SeleneInstance *instance, uint64_t q);
 
 /**
+ * Advance the PRNG with a user-provided delta. As this
+ * is cyclic, i64s with negative values have well defined
+ * rewinding behaviour.
+ *
+ * Requires the PRNG to be seeded with random_seed,
+ * otherwise an error will be returned.
+ */
+struct selene_void_result_t selene_random_advance(struct SeleneInstance *instance, uint64_t delta);
+
+/**
  * Produces a random 32-bit float.
  *
  * Requires the PRNG to be seeded with random_seed,

--- a/selene-sim/python/tests/test_guppy.py
+++ b/selene-sim/python/tests/test_guppy.py
@@ -361,6 +361,37 @@ def test_rng(snapshot):
     snapshot.assert_match(yaml.dump(shots[0]), "rng")
 
 
+@pytest.mark.skipif(
+    not hasattr(RNG, "random_advance"),
+    reason="RNG advance is not implemented in guppy yet",
+)
+def test_rng_advance(snapshot):
+    @guppy
+    def main() -> None:
+        rng = RNG(get_current_shot() + 42)
+        rint = rng.random_int()
+        rfloat = rng.random_float()
+        rng.advance(-2)
+        rint2 = rng.random_int()
+        rfloat2 = rng.random_float()
+        result("rint", rint)
+        result("rint2", rint2)
+        result("rfloat", rfloat)
+        result("rfloat2", rfloat2)
+
+    runner = build(main.compile(), "rng_advance")
+    shots = list(
+        dict(shot) for shot in runner.run_shots(Quest(), 1, n_shots=10, verbose=True)
+    )
+    for shot in shots[1:]:
+        assert shot["rint"] == shot["rint2"], (
+            f"Expected rint to be the same after advancing, got {shot['rint']} and {shot['rint2']}"
+        )
+        assert shot["rfloat"] == shot["rfloat2"], (
+            f"Expected rfloat to be the same after advancing, got {shot['rfloat']} and {shot['rfloat2']}"
+        )
+
+
 def test_sim_restriction():
     """
     Demonstrate the propagation of panic-inducing messages from

--- a/selene-sim/python/tests/test_guppy.py
+++ b/selene-sim/python/tests/test_guppy.py
@@ -383,7 +383,7 @@ def test_rng_advance(snapshot):
     shots = list(
         dict(shot) for shot in runner.run_shots(Quest(), 1, n_shots=10, verbose=True)
     )
-    for shot in shots[1:]:
+    for shot in shots:
         assert shot["rint"] == shot["rint2"], (
             f"Expected rint to be the same after advancing, got {shot['rint']} and {shot['rint2']}"
         )

--- a/selene-sim/rust/ffi_interface.rs
+++ b/selene-sim/rust/ffi_interface.rs
@@ -468,6 +468,20 @@ pub unsafe extern "C" fn selene_random_seed(
     })
 }
 
+/// Advance the PRNG with a user-provided delta. As this
+/// is cyclic, i64s with negative values have well defined
+/// rewinding behaviour.
+///
+/// Requires the PRNG to be seeded with random_seed,
+/// otherwise an error will be returned.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn selene_random_advance(
+    instance: *mut SeleneInstance,
+    delta: u64,
+) -> VoidResult {
+    with_instance_void(instance, |instance| instance.random_advance(delta))
+}
+
 /// Produces a random 32-bit unsigned integer.
 ///
 /// Requires the PRNG to be seeded with random_seed,

--- a/selene-sim/rust/selene_instance/rng.rs
+++ b/selene-sim/rust/selene_instance/rng.rs
@@ -7,6 +7,17 @@ impl SeleneInstance {
     pub fn random_seed(&mut self, seed: u64) {
         self.prng = Some(Pcg32::new(42, seed));
     }
+    /// Advances the PRNG internal state by a specified delta.
+    ///
+    /// This is cyclic in u64, so u64::MAX-(x-1) is equivalent
+    /// to a *rewind* by x.
+    pub fn random_advance(&mut self, delta: u64) -> Result<()> {
+        let Some(ref mut rng) = self.prng else {
+            return Err(anyhow!("PRNG has not been seeded"));
+        };
+        rng.advance(delta);
+        Ok(())
+    }
     /// Produces a random 32-bit unsigned integer.
     pub fn random_u32(&mut self) -> Result<u32> {
         let Some(ref mut rng) = self.prng else {
@@ -14,7 +25,7 @@ impl SeleneInstance {
         };
         Ok(rng.random())
     }
-    /// Produces a random 32-bit float.
+    /// Produces a random 32-bit float in the range [0.0, 1.0).
     pub fn random_f64(&mut self) -> Result<f64> {
         match self.random_u32() {
             Ok(r) => Ok(r as f64 / 2u64.pow(32) as f64),


### PR DESCRIPTION
- Add `selene_random_advance(delta: u64)` function to selene
  - This advances the random state by the specified number of 32 bit reads
  - As this is cyclic in 2^64, a negative value can be bitcast and accepted.
  - If no prng state is set, an error is raised (as with e.g. selene_random_u32)
- Add random_advance to the QIS wrapper, calling the above.
- Add pytest, though it is currently skipped as random_advance support isn't available in guppy yet.

Future work:

I do not like managing static RNG state in selene:
- It's done this way because that's how QIS uses RNG.
- It makes sense there. - but the static state is an antipattern in the context of selene itself.
- Instead, Selene can offer stateful RNG, and we should handle state in the QIS wrapper.