### PR TITLE
chore: separate release workflows

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -280,10 +280,92 @@ jobs:
           path: wheelhouse/*.whl
           if-no-files-found: error
   
-  release:
-    name: Release
+  release-selene-core:
+    name: Release selene-core
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/selene-core-')
+    # selene-core impacts selene-sim, so for now we still run selene-sim through testing before releasing selene-core
+    needs: [build_selene_core, build_platform_specific_wheels] 
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: wheelhouse
+          merge-multiple: true
+
+      - name: GH Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: wheelhouse/*.whl
+          generate_release_notes: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install twine
+        run: python -m pip install twine
+
+      - name: Upload to jfrog
+        run: |
+          twine upload --verbose --non-interactive wheelhouse/selene_core-*.whl
+        env:
+          TWINE_REPOSITORY_URL: ${{ secrets.JFROG_URL }}
+          TWINE_USERNAME: ${{ secrets.JFROG_USER }}
+          TWINE_PASSWORD: ${{ secrets.JFROG_TOKEN }}
+
+      - name: Upload to pypi
+        run: |
+          twine upload --verbose --non-interactive wheelhouse/selene_core-*.whl
+ 
+  release-selene-hugr-qis-compiler-core:
+    name: Release selene-core
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/selene-hugr-qis-compiler-')
+    # selene-hugr-qis-compiler impacts selene-sim, so for now we still run selene-sim through testing before releasing selene-core
+    needs: [build_selene_core, build_platform_specific_wheels] 
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: wheelhouse
+          merge-multiple: true
+
+      - name: GH Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: wheelhouse/*.whl
+          generate_release_notes: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install twine
+        run: python -m pip install twine
+
+      - name: Upload to jfrog
+        run: |
+          twine upload --verbose --non-interactive wheelhouse/selene_hugr-qis-compiler-*.whl
+        env:
+          TWINE_REPOSITORY_URL: ${{ secrets.JFROG_URL }}
+          TWINE_USERNAME: ${{ secrets.JFROG_USER }}
+          TWINE_PASSWORD: ${{ secrets.JFROG_TOKEN }}
+
+      - name: Upload to pypi
+        run: |
+          twine upload --verbose --non-interactive wheelhouse/selene_hugr-qis-compiler-*.whl
+ 
+  release-selene-sim:
+    name: Release selene-sim
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/selene-sim-')
     needs: [build_selene_core, build_platform_specific_wheels]
     permissions:
       contents: write
@@ -310,7 +392,7 @@ jobs:
 
       - name: Upload to jfrog
         run: |
-          twine upload --verbose --non-interactive wheelhouse/*.whl
+          twine upload --verbose --non-interactive wheelhouse/selene_sim-*.whl
         env:
           TWINE_REPOSITORY_URL: ${{ secrets.JFROG_URL }}
           TWINE_USERNAME: ${{ secrets.JFROG_USER }}
@@ -318,4 +400,4 @@ jobs:
 
       - name: Upload to pypi
         run: |
-          twine upload --verbose --non-interactive wheelhouse/*.whl
+          twine upload --verbose --non-interactive wheelhouse/selene_sim-*.whl


### PR DESCRIPTION
Currently, we assume a tight coupling between selene-core, selene-sim, and selene-hugr-qis-compiler - so tight that we expect a version bump across each of them, and a release of all at the same time. In fact, trying to bump only one leads to failure, as it attempts to overwrite existing packages on pypi and jfrog.

This PR aims to separate that flow, such that we can release each independently. This means that an bump of selene-sim does _not_  impact selene-hugr-qis-compiler.

This is useful for CI times, as the selene-hugr-qis-compiler takes a non-negligible amount of time to compile and test. It is cached based on its directory contents, which necessarily includes version information (in the .toml and .lock files). As such if we wish to bump selene-sim itself, we need not bump everything else.

This should open the door for introducing release-please.