### PR TITLE
chore: use stable release-please-action 4.3.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     name: Create release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@update-rp
+      - uses: googleapis/release-please-action@4.3
         with:
           token: ${{ secrets.HUGRBOT_PAT }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     name: Create release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@4.3
+      - uses: googleapis/release-please-action@v4.3.0
         with:
           token: ${{ secrets.HUGRBOT_PAT }}


### PR DESCRIPTION
Previously the release-please-action was tied to a branch with a fix updating release-please. This was needed as an interaction with the GitHub API was no longer working. That PR has now been merged and the source branch deleted, so we point to the new release.