### PR TITLE
feat: Better exception handling for parse_shots=False

### DIFF
--- a/selene-sim/python/selene_sim/instance.py
+++ b/selene-sim/python/selene_sim/instance.py
@@ -118,7 +118,7 @@ class SeleneProcess:
         )
         return self.process
 
-    def wait(self):
+    def wait(self, check_return_code: bool = True):
         """
         Wait for the process to finish and return the return code.
         """
@@ -127,7 +127,7 @@ class SeleneProcess:
                 message="Process has not been spawned yet", stdout="", stderr=""
             )
         self.process.wait()
-        if self.process.returncode:
+        if check_return_code and self.process.returncode:
             raise SeleneRuntimeError(
                 message="Error running user program",
                 stdout=self.stdout.read_text(),
@@ -159,9 +159,9 @@ class SeleneProcessList:
                 return process
         return None
 
-    def wait(self):
+    def wait(self, check_return_code: bool = True):
         for process in self.processes:
-            process.wait()
+            process.wait(check_return_code)
 
 
 @dataclass
@@ -388,14 +388,14 @@ class SeleneInstance:
                 relevant_process = processes.find(shot_idx)
                 assert relevant_process is not None
                 yield parse_shot(
-                    result_stream,
-                    event_hook,
-                    parse_results,
-                    relevant_process.stdout,
-                    relevant_process.stderr,
+                    parser=result_stream,
+                    event_hook=event_hook,
+                    full=parse_results,
+                    stdout_file=relevant_process.stdout,
+                    stderr_file=relevant_process.stderr,
                 )
 
-        processes.wait()
+        processes.wait(check_return_code=parse_results)
 
     def run(
         self,

--- a/selene-sim/python/selene_sim/result_handling/__init__.py
+++ b/selene-sim/python/selene_sim/result_handling/__init__.py
@@ -1,5 +1,5 @@
 from .data_stream import TCPStream, DataStream
-from .result_stream import ResultStream, TaggedResult
+from .result_stream import ResultStream, TaggedResult, DataValue
 from .parse_shot import parse_shot
 
 __all__ = [
@@ -7,5 +7,6 @@ __all__ = [
     "DataStream",
     "ResultStream",
     "TaggedResult",
+    "DataValue",
     "parse_shot",
 ]

--- a/selene-sim/python/selene_sim/result_handling/exception_encoding.py
+++ b/selene-sim/python/selene_sim/result_handling/exception_encoding.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+from typing import Iterator
+from selene_sim.exceptions import (
+    SelenePanicError,
+    SeleneRuntimeError,
+    SeleneStartupError,
+    SeleneTimeoutError,
+)
+from . import TaggedResult
+
+
+# when encoding exceptions through the result stream,
+# these prefixes are used to identify metadata surrounding
+# the error.
+EXCEPTION_TYPE_PREFIX = "_EXCEPTION:INT:"
+STDERR_PREFIX = "_STDERR:INT:"
+STDOUT_PREFIX = "_STDOUT:INT:"
+
+
+def encode_exception(
+    exception: Exception, stdout_file: Path, stderr_file: Path
+) -> Iterator[TaggedResult]:
+    """
+    Given an exception that occurs during a shot, encode it as a series
+    of result stream entries with specific prefixes, so that it can be
+    recovered on the other end of the stream.
+    """
+    match exception:
+        case SelenePanicError(message=message, code=code):
+            # The EXIT:INT: prefix is already present
+            # in the message. The code is provided by
+            # the user program or Selene.
+            yield (message, code)
+            yield (f"{EXCEPTION_TYPE_PREFIX}SelenePanicError", 0)
+            yield (f"{STDERR_PREFIX}{stderr_file}", 0)
+            yield (f"{STDOUT_PREFIX}{stdout_file}", 0)
+        case SeleneRuntimeError(message=message):
+            # We need to encode the EXIT:INT: prefix here,
+            # and provide a generic code.
+            yield (f"EXIT:INT:{message}", 110000)
+            yield (f"{EXCEPTION_TYPE_PREFIX}SeleneRuntimeError", 0)
+            yield (f"{STDERR_PREFIX}{stderr_file}", 0)
+            yield (f"{STDOUT_PREFIX}{stdout_file}", 0)
+        case SeleneStartupError(message=message):
+            # We need to encode the EXIT:INT: prefix here,
+            # and provide a generic code.
+            yield (f"EXIT:INT:{message}", 110001)
+            yield (f"{EXCEPTION_TYPE_PREFIX}SeleneStartupError", 0)
+            yield (f"{STDERR_PREFIX}{stderr_file}", 0)
+            yield (f"{STDOUT_PREFIX}{stdout_file}", 0)
+        case SeleneTimeoutError(message=message):
+            # We need to encode the EXIT:INT: prefix here,
+            # and provide a generic code.
+            yield (f"EXIT:INT:{message}", 110002)
+            yield (f"{EXCEPTION_TYPE_PREFIX}SeleneTimeoutError", 0)
+            yield (f"{STDERR_PREFIX}{stderr_file}", 0)
+            yield (f"{STDOUT_PREFIX}{stdout_file}", 0)
+        case other:
+            # Encapsulate any other exception into a
+            # SeleneRuntimeError for consistent parsing
+            # on the other end.
+            yield (f"EXIT:INT:{other}", 110000)
+            yield ("{EXCEPTION_TYPE_PREFIX}SeleneRuntimeError", 0)
+            yield (f"{STDERR_PREFIX}{stderr_file}", 0)
+            yield (f"{STDOUT_PREFIX}{stdout_file}", 0)
+
+
+def decode_exception(shot_results: list[TaggedResult]) -> Exception | None:
+    """
+    Given a list of shot results, check if the last four entries correspond
+    to an encoded exception. If so, decode it and return the exception object.
+    If not, return None.
+    """
+
+    # If the last 4 tags are EXIT:INT: EXCEPTION_TYPE_PREFIX, STDERR_PREFIX, and
+    # STDOUT_PREFIX, then we have an error to process. Otherwise return None
+    expected_prefixes = [
+        "EXIT:INT:",
+        EXCEPTION_TYPE_PREFIX,
+        STDERR_PREFIX,
+        STDOUT_PREFIX,
+    ]
+    if len(shot_results) < 4:
+        return None
+
+    last_four_tags = list(map(lambda x: x[0], shot_results[-4:]))
+    if not all(last_four_tags[i].startswith(expected_prefixes[i]) for i in range(4)):
+        return None
+
+    error_message = last_four_tags[0].removeprefix("EXIT:INT:")
+    error_code = shot_results[-4][1]
+    exception_type = last_four_tags[1].removeprefix(EXCEPTION_TYPE_PREFIX)
+    stderr_path = last_four_tags[2].removeprefix(STDERR_PREFIX)
+    stdout_path = last_four_tags[3].removeprefix(STDOUT_PREFIX)
+
+    # Satisfy Mypy that the variables are not None
+    assert isinstance(error_message, str)
+    assert isinstance(error_code, int)
+    assert isinstance(exception_type, str)
+    assert isinstance(stderr_path, str)
+    assert isinstance(stdout_path, str)
+
+    match exception_type:
+        case "SelenePanicError":
+            return SelenePanicError(
+                message=error_message,
+                code=error_code,
+                stdout=Path(stdout_path).read_text(),
+                stderr=Path(stderr_path).read_text(),
+            )
+        case "SeleneRuntimeError":
+            return SeleneRuntimeError(
+                message=error_message,
+                stdout=Path(stdout_path).read_text(),
+                stderr=Path(stderr_path).read_text(),
+            )
+        case "SeleneStartupError":
+            return SeleneStartupError(
+                message=error_message,
+                stdout=Path(stdout_path).read_text(),
+                stderr=Path(stderr_path).read_text(),
+            )
+        case "SeleneTimeoutError":
+            return SeleneTimeoutError(
+                message=error_message,
+                stdout=Path(stdout_path).read_text(),
+                stderr=Path(stderr_path).read_text(),
+            )
+        case _:
+            raise RuntimeError(f"Unknown exception type: {exception_type}")


### PR DESCRIPTION
Context: `parse_shots=False` provides a mode where all events in the result stream are passed on to the user, rather than going through full parsing and processing within the guts of selene itself. The users of this mode are those in 'black box' hosted applications that use result stream interfaces to communicate with other components.

A limitation of the current implementation is that exception handling is too coarse.
- Exceptions are weakly avoided, as they could prevent passing partial shot information along to the user
- Error Messages are passed in the result stream, but no stdout/stderr information that may provide important context.
- There is insufficient room in the tag to pass that information along
- A user program panic leads to the remaining shots looking seemingly empty, failing to indicate that they never ran.

This PR aims to improve things considerably.
- parsed and unparsed handling is now done in separate functions, cleaning things up a bit
- *all* exceptions are passed into the result stream.
- (path to) stdout, (path to) stderr, and the exception type are also passed into the result stream under _STDOUT, _STDERR, _EXCEPTION tags.
- helper functions are provided to recover the original exception information from the other end of the stream.

An example of using the stream interface to recover errors:
```python
shots, error = postprocess_unparsed_stream(
    runner.run_shots(
        Quest(random_seed=1234),
        n_qubits=1,
        n_shots=100,
        timeout=datetime.timedelta(seconds=0),
        n_processes=4,
        parse_results=False,
    )
)
```

such that `type(error) in [None, SelenePanicError, SeleneTimeoutError, SeleneStartupError, SeleneRuntimeError]` and such that `shots` contains all successful shot result lists _and_ the failed shot result list if any. Shots after error are not processed.