### PR TITLE
fix: correct post_runtime duration metric

### DIFF
--- a/selene-sim/rust/event_hooks/metrics.rs
+++ b/selene-sim/rust/event_hooks/metrics.rs
@@ -157,7 +157,7 @@ impl PostRuntimeMetrics {
             }
         }
 
-        self.total_duration_ns += std::cmp::max(
+        self.total_duration_ns = std::cmp::max(
             self.total_duration_ns,
             u64::from(batch.start()) + u64::from(batch.duration()),
         );


### PR DESCRIPTION
This metric used to add the duration to its previous value. This lead to some issues with overlapping batches so it was amended to use a maximum of itself and the end time of the batch. However, this change was faulty and added the aforementioned maximum to itself rather than setting its value as that maximum. This PR fixes that.