### PR TITLE
feat: Build improvements

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -118,9 +118,8 @@ jobs:
             /tmp/ci-cache/selene
             target/
           key: selene-sim--build-env--${{ matrix.os }}--${{ hashFiles('Cargo.lock') }}
-          # purge cache
-          #restore-keys: |
-          #  selene-sim--build-env--${{ matrix.os }}--
+          restore-keys: |
+            selene-sim--build-env--${{ matrix.os }}--
 
       # Perform the selene-sim build
       - name: Build selene-sim wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,7 @@ before-all = '''
         cp -r /host/tmp/ci-cache/selene/target {project};
     fi;
     # grab rust
-    curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+    curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.94-$(uname -m)-unknown-linux-gnu -y
 '''
 before-test = '''
     # if we have caching enabled and it exists, copy caches to the
@@ -224,7 +224,7 @@ before-test = '''
 [tool.cibuildwheel.macos]
 environment = { PATH = "$PATH:$HOME/.cargo/bin", MACOSX_DEPLOYMENT_TARGET = "11.0" }
 before-all = [
-    'curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y'
+    'curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.94-$(uname -m)-apple-darwin -y'
 ]
 before-test = [
     'uv pip install ./selene-core'
@@ -232,7 +232,7 @@ before-test = [
 [tool.cibuildwheel.windows]
 environment = { PATH = "$PATH:$HOME/.cargo/bin", CARGO_BUILD_TARGET = "x86_64-pc-windows-gnu" }
 before-all = [
-    'curl -sSf https://sh.rustup.rs | sh -s -- -y',
+    'curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.94-x86_64-pc-windows-gnu -y',
     'rustup target add x86_64-pc-windows-gnu'
 ]
 before-test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,8 @@ before-all = '''
         cp -r /host/tmp/ci-cache/selene/target {project};
     fi;
     # grab rust
-    curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.94-$(uname -m)-unknown-linux-gnu -y
+    curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+    rustup toolchain install;
 '''
 before-test = '''
     # if we have caching enabled and it exists, copy caches to the
@@ -224,7 +225,8 @@ before-test = '''
 [tool.cibuildwheel.macos]
 environment = { PATH = "$PATH:$HOME/.cargo/bin", MACOSX_DEPLOYMENT_TARGET = "11.0" }
 before-all = [
-    'curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.94-$(uname -m)-apple-darwin -y'
+    'curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y',
+    'rustup toolchain install',
 ]
 before-test = [
     'uv pip install ./selene-core'
@@ -232,7 +234,8 @@ before-test = [
 [tool.cibuildwheel.windows]
 environment = { PATH = "$PATH:$HOME/.cargo/bin", CARGO_BUILD_TARGET = "x86_64-pc-windows-gnu" }
 before-all = [
-    'curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.94-x86_64-pc-windows-gnu -y',
+    'curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y',
+    'rustup toolchain install',
     'rustup target add x86_64-pc-windows-gnu'
 ]
 before-test = [

--- a/selene-core/python/selene_core/build_utils/builtins/helios.py
+++ b/selene-core/python/selene_core/build_utils/builtins/helios.py
@@ -208,6 +208,7 @@ class HeliosLLVMIRFileToHeliosObjectFileStep(Step):
             "-o",
             out_path,
             verbose=build_ctx.verbose,
+            cache_dir=build_ctx.artifact_dir,
         )
         return cls._make_artifact(out_path)
 
@@ -225,7 +226,14 @@ class HeliosLLVMBitcodeFileToHeliosObjectFileStep(Step):
         out_path = build_ctx.artifact_dir / "program.helios.o"
         if build_ctx.verbose:
             print(f"Compiling LLVM Bitcode to Helios-QIS object: {out_path}")
-        invoke_zig("cc", "-c", input_artifact.resource, "-o", out_path)
+        invoke_zig(
+            "cc",
+            "-c",
+            input_artifact.resource,
+            "-o",
+            out_path,
+            cache_dir=build_ctx.artifact_dir,
+        )
         return cls._make_artifact(out_path)
 
 
@@ -295,6 +303,7 @@ class HeliosObjectFileToSeleneObjectFileStep_Linux(Step):
             "-o",
             out_path,
             verbose=build_ctx.verbose,
+            cache_dir=build_ctx.artifact_dir,
         )
         return cls._make_artifact(out_path)
 
@@ -348,6 +357,7 @@ class HeliosObjectFileToSeleneExecutableStep_Windows(Step):
             input_artifact.resource,
             *libraries,
             *link_flags,
+            cache_dir=build_ctx.artifact_dir,
         )
         return cls._make_artifact(
             out_path,
@@ -402,6 +412,7 @@ class HeliosObjectFileToSeleneExecutableStep_Darwin(Step):
             input_artifact.resource,
             *libraries,
             *link_flags,
+            cache_dir=build_ctx.artifact_dir,
         )
         return cls._make_artifact(
             out_path,

--- a/selene-core/python/selene_core/build_utils/builtins/helios.py
+++ b/selene-core/python/selene_core/build_utils/builtins/helios.py
@@ -201,6 +201,8 @@ class HeliosLLVMIRFileToHeliosObjectFileStep(Step):
         out_path = build_ctx.artifact_dir / "program.helios.o"
         if build_ctx.verbose:
             print(f"Compiling LLVM IR to Helios-QIS object: {out_path}")
+        zig_cache_dir = build_ctx.artifact_dir / "zig-cache"
+        zig_cache_dir.mkdir(exist_ok=True)
         invoke_zig(
             "cc",
             "-c",
@@ -208,7 +210,7 @@ class HeliosLLVMIRFileToHeliosObjectFileStep(Step):
             "-o",
             out_path,
             verbose=build_ctx.verbose,
-            cache_dir=build_ctx.artifact_dir,
+            cache_dir=zig_cache_dir,
         )
         return cls._make_artifact(out_path)
 
@@ -226,13 +228,15 @@ class HeliosLLVMBitcodeFileToHeliosObjectFileStep(Step):
         out_path = build_ctx.artifact_dir / "program.helios.o"
         if build_ctx.verbose:
             print(f"Compiling LLVM Bitcode to Helios-QIS object: {out_path}")
+        zig_cache_dir = build_ctx.artifact_dir / "zig-cache"
+        zig_cache_dir.mkdir(exist_ok=True)
         invoke_zig(
             "cc",
             "-c",
             input_artifact.resource,
             "-o",
             out_path,
-            cache_dir=build_ctx.artifact_dir,
+            cache_dir=zig_cache_dir,
         )
         return cls._make_artifact(out_path)
 
@@ -295,6 +299,8 @@ class HeliosObjectFileToSeleneObjectFileStep_Linux(Step):
         lib_paths = [d.path for d in build_ctx.deps]
         if build_ctx.verbose:
             print("Linking helios object file with dependencies")
+        zig_cache_dir = build_ctx.artifact_dir / "zig-cache"
+        zig_cache_dir.mkdir(exist_ok=True)
         invoke_zig(
             "cc",
             "-r",
@@ -303,7 +309,7 @@ class HeliosObjectFileToSeleneObjectFileStep_Linux(Step):
             "-o",
             out_path,
             verbose=build_ctx.verbose,
-            cache_dir=build_ctx.artifact_dir,
+            cache_dir=zig_cache_dir,
         )
         return cls._make_artifact(out_path)
 
@@ -351,13 +357,15 @@ class HeliosObjectFileToSeleneExecutableStep_Windows(Step):
 
         if build_ctx.verbose:
             print("Linking selene object file with selene core library")
+        zig_cache_dir = build_ctx.artifact_dir / "zig-cache"
+        zig_cache_dir.mkdir(exist_ok=True)
         invoke_zig(
             "build-exe",
             f"-femit-bin={out_path}",
             input_artifact.resource,
             *libraries,
             *link_flags,
-            cache_dir=build_ctx.artifact_dir,
+            cache_dir=zig_cache_dir,
         )
         return cls._make_artifact(
             out_path,
@@ -406,13 +414,15 @@ class HeliosObjectFileToSeleneExecutableStep_Darwin(Step):
 
         if build_ctx.verbose:
             print("Linking selene object file with selene core library")
+        zig_cache_dir = build_ctx.artifact_dir / "zig-cache"
+        zig_cache_dir.mkdir(exist_ok=True)
         invoke_zig(
             "build-exe",
             f"-femit-bin={out_path}",
             input_artifact.resource,
             *libraries,
             *link_flags,
-            cache_dir=build_ctx.artifact_dir,
+            cache_dir=zig_cache_dir,
         )
         return cls._make_artifact(
             out_path,

--- a/selene-core/python/selene_core/build_utils/builtins/selene.py
+++ b/selene-core/python/selene_core/build_utils/builtins/selene.py
@@ -131,8 +131,6 @@ class SeleneObjectToSeleneExecutable(Step):
             link_flags.extend(dep.link_flags)
             library_search_dirs.extend(dep.library_search_dirs)
 
-        # cache_option = f"--cache-dir=" + str(build_ctx.cache_dir)]
-
         if build_ctx.verbose:
             print("Linking selene object file with selene core library")
         invoke_zig(

--- a/selene-core/python/selene_core/build_utils/builtins/selene.py
+++ b/selene-core/python/selene_core/build_utils/builtins/selene.py
@@ -133,6 +133,8 @@ class SeleneObjectToSeleneExecutable(Step):
 
         if build_ctx.verbose:
             print("Linking selene object file with selene core library")
+        zig_cache_dir = build_ctx.artifact_dir / "zig-cache"
+        zig_cache_dir.mkdir(exist_ok=True)
         invoke_zig(
             "cc",
             "-o",
@@ -140,7 +142,7 @@ class SeleneObjectToSeleneExecutable(Step):
             input_artifact.resource,
             selene_lib,
             *link_flags,
-            cache_dir=build_ctx.artifact_dir,
+            cache_dir=zig_cache_dir,
         )
         return cls._make_artifact(
             out_path,

--- a/selene-core/python/selene_core/build_utils/builtins/selene.py
+++ b/selene-core/python/selene_core/build_utils/builtins/selene.py
@@ -131,10 +131,18 @@ class SeleneObjectToSeleneExecutable(Step):
             link_flags.extend(dep.link_flags)
             library_search_dirs.extend(dep.library_search_dirs)
 
+        # cache_option = f"--cache-dir=" + str(build_ctx.cache_dir)]
+
         if build_ctx.verbose:
             print("Linking selene object file with selene core library")
         invoke_zig(
-            "cc", "-o", out_path, input_artifact.resource, selene_lib, *link_flags
+            "cc",
+            "-o",
+            out_path,
+            input_artifact.resource,
+            selene_lib,
+            *link_flags,
+            cache_dir=build_ctx.artifact_dir,
         )
         return cls._make_artifact(
             out_path,

--- a/selene-core/python/selene_core/build_utils/utils.py
+++ b/selene-core/python/selene_core/build_utils/utils.py
@@ -52,9 +52,13 @@ def invoke_zig(
     handle_triple: bool = True,
     verbose: bool = False,
     cache_dir: Path | None = None,
-) -> str:
+) -> None:
     """
     Invoke zig with the given arguments, after conversion to strings.
+
+    When verbose is True, zig's stdout is forwarded to the console so that
+    long-running builds remain observable. stderr is always captured so that
+    a helpful message can be included in any RuntimeError raised on failure.
     """
     import subprocess
 
@@ -69,12 +73,14 @@ def invoke_zig(
     env = os.environ.copy()
     if cache_dir is not None:
         env["ZIG_LOCAL_CACHE_DIR"] = str(cache_dir)
+    # Inherit stdout when verbose so progress is visible; suppress it otherwise.
+    # Always capture stderr so we can include it in any error message.
+    stdout_target = None if verbose else subprocess.DEVNULL
     handle = subprocess.Popen(
-        argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        argv, stdout=stdout_target, stderr=subprocess.PIPE, env=env
     )
-    stdout, stderr = handle.communicate()
+    _, stderr = handle.communicate()
     if handle.returncode != 0:
         raise RuntimeError(
             f"zig command failed:\n  Command: {' '.join(argv)}\n  Error: {stderr.decode()}"
         )
-    return stdout.decode()

--- a/selene-core/python/selene_core/build_utils/utils.py
+++ b/selene-core/python/selene_core/build_utils/utils.py
@@ -2,6 +2,8 @@
 
 import platform
 import sys
+from pathlib import Path
+import os
 
 
 def get_target_triple(arch: str | None = None, system: str | None = None) -> str | None:
@@ -45,7 +47,7 @@ def get_target_triple(arch: str | None = None, system: str | None = None) -> str
     return f"{target_arch}-{target_system}"
 
 
-def invoke_zig(*args, handle_triple=True, verbose=False) -> str:
+def invoke_zig(*args, handle_triple=True, verbose=False, cache_dir=None) -> str:
     """
     Invoke zig with the given arguments, after conversion to strings.
     """
@@ -59,9 +61,16 @@ def invoke_zig(*args, handle_triple=True, verbose=False) -> str:
     argv = [sys.executable, "-m", "ziglang"] + args_str
     if verbose:
         print(f"zig command: {' '.join(argv)}")
-    handle = subprocess.run(argv, stdout=None, stderr=subprocess.PIPE, text=True)
+    env = os.environ.copy()
+    if cache_dir is not None:
+        env["ZIG_LOCAL_CACHE_DIR"] = str(cache_dir)
+    handle = subprocess.Popen(
+        argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+    )
+    stdout, stderr = handle.communicate()
     if handle.returncode != 0:
         raise RuntimeError(
-            f"zig command failed:\n  Command: {' '.join(argv)}\n  Error: {handle.stderr}"
+            f"zig command failed:\n  Command: {' '.join(argv)}\n  Error: {stderr.decode()}"
         )
+
     return handle.stdout

--- a/selene-core/python/selene_core/build_utils/utils.py
+++ b/selene-core/python/selene_core/build_utils/utils.py
@@ -72,5 +72,4 @@ def invoke_zig(*args, handle_triple=True, verbose=False, cache_dir=None) -> str:
         raise RuntimeError(
             f"zig command failed:\n  Command: {' '.join(argv)}\n  Error: {stderr.decode()}"
         )
-
-    return handle.stdout
+    return stdout.decode()

--- a/selene-core/python/selene_core/build_utils/utils.py
+++ b/selene-core/python/selene_core/build_utils/utils.py
@@ -47,7 +47,12 @@ def get_target_triple(arch: str | None = None, system: str | None = None) -> str
     return f"{target_arch}-{target_system}"
 
 
-def invoke_zig(*args, handle_triple=True, verbose=False, cache_dir=None) -> str:
+def invoke_zig(
+    *args,
+    handle_triple: bool = True,
+    verbose: bool = False,
+    cache_dir: Path | None = None,
+) -> str:
     """
     Invoke zig with the given arguments, after conversion to strings.
     """

--- a/selene-sim/python/selene_sim/build.py
+++ b/selene-sim/python/selene_sim/build.py
@@ -118,6 +118,11 @@ def build(
         strict: If True, intermediate artifacts will be validated against their kinds
                 on each step. This is more expensive, and is only recommended when
                 debugging or developing new artifact kinds and build steps.
+        complete_manifest: If True, the written manifest will include all intermediate
+                           artifacts produced during the build, providing a complete
+                           picture of all build stages. If False (default), only the
+                           final binary artifact is recorded in the manifest, which
+                           reduces manifest size and the time taken to write it.
     Returns:
         An SeleneInstance object representing the built selene runner
     """

--- a/selene-sim/python/selene_sim/build.py
+++ b/selene-sim/python/selene_sim/build.py
@@ -82,6 +82,7 @@ def build(
     progress_bar: bool = False,
     strict: bool = False,
     save_planner: bool = False,
+    complete_manifest: bool = False,
     **kwargs,
 ) -> SeleneInstance:
     """
@@ -250,7 +251,7 @@ def build(
             "created_by": "selene-build 0.1",
             "deps": [d.__dict__ for d in deps],
             "steps": steps,
-            "artifacts": artifacts,
+            "artifacts": artifacts if complete_manifest else [artifacts[-1]],
             "library_search_dirs": library_search_dirs,
         }
     )


### PR DESCRIPTION
Addresses two recent feedback items:
- zig pollutes the user's .cache/zig directory, which may grow large
- Selene manifests take too long to write

The first item is managed by providing zig with a cache dir, which subsequently sets `ZIG_LOCAL_CACHE_DIR` in the subprocess environment.

The second is managed by providing a `complete_manifest` bool flag to `build()`. When True, the manifest aims to be a complete picture of the build stages, for use with sharing and diagnosis. When False (default), less information is written to the manifest. At current this reduced information is in the form of stripping input artifact or intermediate artifacts in the manifest, keeping only the final binary.