### PR TITLE
feat: Record simulated delays in event hooks

### DIFF
--- a/selene-sim/python/selene_sim/event_hooks/instruction_log.py
+++ b/selene-sim/python/selene_sim/event_hooks/instruction_log.py
@@ -300,6 +300,22 @@ class FutureRead(Operation):
         return FutureRead(qubit=next(it))
 
 
+@dataclass
+class ClassicalDelay(Operation):
+    duration_ns: int
+
+    def append_to_circuit(self, circuit: "pytket.Circuit"):
+        pass
+
+    def to_dict(self) -> dict:
+        return {"op": "ClassicalDelay", "duration_ns": self.duration_ns}
+
+    @staticmethod
+    def from_iterator(it: Iterator):
+        duration_ns = next(it)
+        return ClassicalDelay(duration_ns=duration_ns)
+
+
 class Source(Enum):
     """
     Selene provides the source of each instruction as an
@@ -370,6 +386,8 @@ class Instruction:
                 operation = GlobalBarrier.from_iterator(it)
             case 12:
                 operation = MeasureLeakedRequest.from_iterator(it)
+            case 13:
+                operation = ClassicalDelay.from_iterator(it)
         if operation is None:
             raise ValueError(f"Unknown instruction operation index {operation_idx}")
         return Instruction(source=source, operation=operation)

--- a/selene-sim/python/tests/test_qis.py
+++ b/selene-sim/python/tests/test_qis.py
@@ -113,3 +113,150 @@ def test_simulate_delay():
         {"op": "BatchStart", "start_time_ns": 1234500000, "duration_ns": 0},
         {"op": "FutureRead", "qubit": 1},
     ]
+
+    all_output = list(helios_circuit_extractor.shots[0])
+    all_output_serialised = []
+    for item in all_output:
+        all_output_serialised.append(
+            {"source": str(item.source), "operation": item.operation.to_dict()}
+        )
+
+    assert all_output_serialised == [
+        {
+            "operation": {
+                "op": "QAlloc",
+                "qubit": 0,
+            },
+            "source": "Source.USER",
+        },
+        {
+            "operation": {
+                "op": "QAlloc",
+                "qubit": 1,
+            },
+            "source": "Source.USER",
+        },
+        {
+            "operation": {
+                "op": "Reset",
+                "qubit": 0,
+            },
+            "source": "Source.USER",
+        },
+        {
+            "operation": {
+                "duration_ns": 0,
+                "op": "BatchStart",
+                "start_time_ns": 0,
+            },
+            "source": "Source.OPTIMISER",
+        },
+        {
+            "operation": {
+                "op": "Reset",
+                "qubit": 0,
+            },
+            "source": "Source.OPTIMISER",
+        },
+        {
+            "operation": {
+                "op": "Reset",
+                "qubit": 1,
+            },
+            "source": "Source.USER",
+        },
+        {
+            "operation": {
+                "duration_ns": 0,
+                "op": "BatchStart",
+                "start_time_ns": 0,
+            },
+            "source": "Source.OPTIMISER",
+        },
+        {
+            "operation": {
+                "op": "Reset",
+                "qubit": 1,
+            },
+            "source": "Source.OPTIMISER",
+        },
+        {
+            "operation": {
+                "op": "MeasureRequest",
+                "qubit": 0,
+            },
+            "source": "Source.USER",
+        },
+        {
+            "operation": {
+                "duration_ns": 0,
+                "op": "BatchStart",
+                "start_time_ns": 0,
+            },
+            "source": "Source.OPTIMISER",
+        },
+        {
+            "operation": {
+                "op": "FutureRead",
+                "qubit": 0,
+            },
+            "source": "Source.OPTIMISER",
+        },
+        {
+            "operation": {
+                "op": "QFree",
+                "qubit": 0,
+            },
+            "source": "Source.USER",
+        },
+        {
+            "operation": {
+                "op": "FutureRead",
+                "qubit": 0,
+            },
+            "source": "Source.USER",
+        },
+        {
+            "operation": {
+                "duration_ns": 1234500000,
+                "op": "ClassicalDelay",
+            },
+            "source": "Source.USER",
+        },
+        {
+            "operation": {
+                "op": "MeasureRequest",
+                "qubit": 1,
+            },
+            "source": "Source.USER",
+        },
+        {
+            "operation": {
+                "duration_ns": 0,
+                "op": "BatchStart",
+                "start_time_ns": 1234500000,
+            },
+            "source": "Source.OPTIMISER",
+        },
+        {
+            "operation": {
+                "op": "FutureRead",
+                "qubit": 1,
+            },
+            "source": "Source.OPTIMISER",
+        },
+        {
+            "operation": {
+                "op": "QFree",
+                "qubit": 1,
+            },
+            "source": "Source.USER",
+        },
+        {
+            "operation": {
+                "op": "FutureRead",
+                "qubit": 1,
+            },
+            "source": "Source.USER",
+        },
+    ]

--- a/selene-sim/rust/emulator.rs
+++ b/selene-sim/rust/emulator.rs
@@ -183,9 +183,9 @@ impl Emulator {
     }
 
     pub fn simulate_delay(&mut self, delay_ns: u64) -> Result<()> {
+        self.runtime.simulate_delay(delay_ns)?;
         self.event_hooks
             .on_user_call(&Operation::ClassicalDelay(delay_ns));
-        self.runtime.simulate_delay(delay_ns)?;
         self.process_runtime()
     }
 }

--- a/selene-sim/rust/emulator.rs
+++ b/selene-sim/rust/emulator.rs
@@ -183,6 +183,8 @@ impl Emulator {
     }
 
     pub fn simulate_delay(&mut self, delay_ns: u64) -> Result<()> {
+        self.event_hooks
+            .on_user_call(&Operation::ClassicalDelay(delay_ns));
         self.runtime.simulate_delay(delay_ns)?;
         self.process_runtime()
     }

--- a/selene-sim/rust/event_hooks.rs
+++ b/selene-sim/rust/event_hooks.rs
@@ -21,6 +21,7 @@ pub enum Operation {
     GlobalBarrier(u64),
     LocalBarrier(Vec<u64>, u64),
     Custom(u64, Vec<u8>),
+    ClassicalDelay(u64),
 }
 
 pub trait EventHook {

--- a/selene-sim/rust/event_hooks/instruction_log.rs
+++ b/selene-sim/rust/event_hooks/instruction_log.rs
@@ -82,6 +82,10 @@ impl Instruction {
                 encoder.write(12u64)?;
                 encoder.write(*qubit1)?;
             }
+            Operation::ClassicalDelay(duration) => {
+                encoder.write(13u64)?;
+                encoder.write(*duration)?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Although simulated delays' impacts can be seen indirectly through timing information, we should record them explicitly in event hooks so that users can use the information however they see fit, e.g. statistical analyses of simulated delays in a program run.

closes #153 