### PR TITLE
fix: classify lowered qir-qis bitcode as helios

### DIFF
--- a/selene-core/python/selene_core/build_utils/builtins/qir.py
+++ b/selene-core/python/selene_core/build_utils/builtins/qir.py
@@ -1,17 +1,38 @@
 from pathlib import Path
 from typing import Any
 
-from .helios import HeliosLLVMBitcodeStringKind
+from .helios import HeliosLLVMBitcodeStringKind, _match_helios_qis
 from ..planner import BuildPlanner
 from ..types import ArtifactKind, Step, BuildCtx, Artifact
+from ..symbols import get_symbols_from_llvm
 
-from qir_qis import qir_ll_to_bc, qir_to_qis, validate_qir
+from qir_qis import get_entry_attributes, qir_ll_to_bc, qir_to_qis, validate_qir
 
-QIR_MATCHES = [
-    "__quantum__qis",
-    "__quantum__rt",
-    "entry_point",
-]
+
+def _matches_qir_ir(text: str) -> bool:
+    try:
+        symbols = get_symbols_from_llvm(text)
+    except Exception:
+        return False
+    if _match_helios_qis(symbols):
+        return False
+    return '"entry_point"' in text
+
+
+def _matches_qir_bitcode(bitcode: bytes) -> bool:
+    magic_numbers = [
+        b"BC\xc0\xde",  # modern bitcode stream, observed on linux and windows runs
+        b"\xde\xc0\x17\x0b",  # legacy bitcode wrapper, observed on macOS runs
+    ]
+    if not any(bitcode.startswith(magic) for magic in magic_numbers):
+        return False
+    try:
+        symbols = get_symbols_from_llvm(bitcode)
+    except Exception:
+        return False
+    if _match_helios_qis(symbols):
+        return False
+    return bool(get_entry_attributes(bitcode))
 
 
 class QIRIRFileKind(ArtifactKind):
@@ -25,8 +46,7 @@ class QIRIRFileKind(ArtifactKind):
             return False
         if resource.suffix != ".ll":
             return False
-        contents = resource.read_text()
-        return any(match in contents for match in QIR_MATCHES)
+        return _matches_qir_ir(resource.read_text())
 
 
 class QIRIRStringKind(ArtifactKind):
@@ -38,7 +58,7 @@ class QIRIRStringKind(ArtifactKind):
             resource = resource.ir
         if not isinstance(resource, str):
             return False
-        return any(match in resource for match in QIR_MATCHES)
+        return _matches_qir_ir(resource)
 
 
 class QIRBitcodeFileKind(ArtifactKind):
@@ -52,8 +72,7 @@ class QIRBitcodeFileKind(ArtifactKind):
             return False
         if resource.suffix != ".bc":
             return False
-        contents = resource.read_bytes()
-        return any(match.encode("utf-8") in contents for match in QIR_MATCHES)
+        return _matches_qir_bitcode(resource.read_bytes())
 
 
 class QIRBitcodeStringKind(ArtifactKind):
@@ -65,13 +84,7 @@ class QIRBitcodeStringKind(ArtifactKind):
             resource = resource.bitcode
         if not isinstance(resource, bytes):
             return False
-        magic_numbers = [
-            b"BC\xc0\xde",  # modern bitcode stream, observed on linux and windows runs
-            b"\xde\xc0\x17\x0b",  # legacy bitcode wrapper, observed on macOS runs
-        ]
-        if not any(resource.startswith(magic) for magic in magic_numbers):
-            return False
-        return any(match.encode("utf-8") in resource for match in QIR_MATCHES)
+        return _matches_qir_bitcode(resource)
 
 
 class QIRIRStringToQIRIRFileStep(Step):

--- a/selene-sim/python/tests/test_build_classification.py
+++ b/selene-sim/python/tests/test_build_classification.py
@@ -1,0 +1,45 @@
+from qir_qis import qir_ll_to_bc, qir_to_qis
+
+from selene_core.build_utils import DEFAULT_BUILD_PLANNER
+from selene_core.build_utils.builtins.helios import HeliosLLVMBitcodeStringKind
+from selene_core.build_utils.builtins.qir import QIRBitcodeStringKind
+
+
+LLVM_IR = """
+%Qubit = type opaque
+%Result = type opaque
+
+define void @ENTRYPOINT__main() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "entry_point" "output_labeling_schema"="schema_id" "required_num_qubits"="1" "required_num_results"="1" "qir_profiles"="adaptive_profile" }
+"""
+
+
+def test_qir_bitcode_is_classified_as_qir():
+    qir_bc = qir_ll_to_bc(LLVM_IR)
+
+    assert QIRBitcodeStringKind.matches(qir_bc)
+    assert DEFAULT_BUILD_PLANNER.identify_kind(qir_bc) is QIRBitcodeStringKind
+
+
+def test_translated_qis_bitcode_is_classified_as_helios():
+    qis_bc = qir_to_qis(qir_ll_to_bc(LLVM_IR))
+
+    assert not QIRBitcodeStringKind.matches(qis_bc)
+    assert HeliosLLVMBitcodeStringKind.matches(qis_bc)
+    assert DEFAULT_BUILD_PLANNER.identify_kind(qis_bc) is HeliosLLVMBitcodeStringKind
+
+
+def test_helios_shape_wins_even_if_stale_qir_entrypoint_metadata_remains(monkeypatch):
+    qis_bc = qir_to_qis(qir_ll_to_bc(LLVM_IR))
+
+    monkeypatch.setattr(
+        "selene_core.build_utils.builtins.qir.get_entry_attributes",
+        lambda _: {"entry_point": None},
+    )
+
+    assert not QIRBitcodeStringKind.matches(qis_bc)
+    assert DEFAULT_BUILD_PLANNER.identify_kind(qis_bc) is HeliosLLVMBitcodeStringKind


### PR DESCRIPTION
## Summary
Classify QIR inputs semantically instead of by raw byte-string matches so already-lowered Helios/QIS bitcode is not routed back through QIR validation.

## Root Cause
On Windows, `qir-qis` can leave dead QIR declarations or entrypoint metadata in translated bitcode when optimization does not fully eliminate them. Selene previously identified QIR bitcode by scanning for raw strings like `entry_point` and `__quantum__qis`, so translated QIS bytes could be misclassified as QIR before Helios matching ran.

## Changes
- reject modules that already match the lowered Helios/QIS symbol shape before treating them as QIR
- require real QIR entrypoint metadata for QIR bitcode classification instead of raw string scans
- add regression tests for QIR input, translated QIS input, and stale-QIR-metadata classification

Resolves #156