### PR TITLE
feat: Analytics

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,6 +27,7 @@ generate-plugin-header plugin:
     rm -rf target/tmp
 
 
+
 generate-selene-core-headers:
     cbindgen \
       --config selene-core/cbindgen.toml \

--- a/selene-core/hatch_build.py
+++ b/selene-core/hatch_build.py
@@ -9,10 +9,14 @@ class SeleneCoreBuildHook(BuildHookInterface):
         # as selene_core isn't yet available we need to import selene_core/trace.py manually
         import importlib.util
 
+        trace_module_path = Path("python/selene_core/trace.py")
         spec = importlib.util.spec_from_file_location(
-            "selene_core.trace", "python/selene_core/trace.py"
+            "selene_core.trace", trace_module_path
         )
-        assert spec is not None and spec.loader is not None
+        if spec is None or spec.loader is None:
+            raise RuntimeError(
+                f"Unable to load module spec for selene_core.trace from {trace_module_path}"
+            )
         trace_module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(trace_module)
         schema_path = Path(

--- a/selene-core/hatch_build.py
+++ b/selene-core/hatch_build.py
@@ -1,9 +1,28 @@
+import json
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from pathlib import Path
 
 
 class SeleneCoreBuildHook(BuildHookInterface):
     def initialize(self, version: str, build_data: dict) -> None:
+        # Generate and write the Trace JSON schema into _dist
+        # as selene_core isn't yet available we need to import selene_core/trace.py manually
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "selene_core.trace", "python/selene_core/trace.py"
+        )
+        assert spec is not None and spec.loader is not None
+        trace_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(trace_module)
+        schema_path = Path(
+            "python/selene_core/_dist/share/selene-core/schemas/trace.json"
+        )
+        schema_path.parent.mkdir(parents=True, exist_ok=True)
+        schema_path.write_text(
+            json.dumps(trace_module.Trace.model_json_schema(), indent=2)
+        )
+
         artifacts = []
         dist_dir = Path("python/selene_core/_dist")
         for artifact in dist_dir.rglob("*"):

--- a/selene-core/pyproject.toml
+++ b/selene-core/pyproject.toml
@@ -26,7 +26,7 @@ homepage = "https://github.com/quantinuum/selene/selene-core"
 repository = "https://github.com/quantinuum/selene/selene-core"
 
 [build-system]
-requires = ["hatchling", "pydantic"]
+requires = ["hatchling", "pydantic>=2.12.5"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]

--- a/selene-core/pyproject.toml
+++ b/selene-core/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "llvmlite==0.45.1; sys_platform == 'darwin' and platform_machine == 'x86_64'",
   "llvmlite~=0.47; sys_platform != 'darwin' or platform_machine != 'x86_64'",
   "networkx>=2.6,<4",
+  "pydantic>=2.12.5",
   "pydot>=4.0.0",
   "pyyaml~=6.0",
   "qir-qis>=0.1.2,<0.1.4",
@@ -25,7 +26,7 @@ homepage = "https://github.com/quantinuum/selene/selene-core"
 repository = "https://github.com/quantinuum/selene/selene-core"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "pydantic"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
@@ -40,6 +41,7 @@ cache-keys = [
   { file = "examples/**/*.rs" },
   { file = "examples/**/Cargo.lock" },
   { file = "examples/**/Cargo.toml" },
+  { file = "python/selene_core/trace.py" },
   { file = "c/include/selene/*.h" },
   { file = "Cargo.toml" },
 ]

--- a/selene-core/python/selene_core/trace.py
+++ b/selene-core/python/selene_core/trace.py
@@ -1,0 +1,97 @@
+from typing import Annotated, Literal, Union
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PredicateResult(BaseModel):
+    predicate: str
+    result: bool
+
+
+class UserProgramSource(BaseModel):
+    kind: Literal["UserProgram"] = "UserProgram"
+    index: int
+
+
+class RuntimeSource(BaseModel):
+    kind: Literal["Runtime"] = "Runtime"
+    start_time: int
+    end_time: int
+
+
+# in future we hope to add ErrorModelSource, so we can keep track of noise.
+# this will require a breaking change, as the error model doesn't presently
+# command the simulator via selene's internals (where logging can be done),
+# but instead controls a simulator directly.
+
+
+class AbstractEvent(BaseModel):
+    model_config = ConfigDict(
+        use_enum_values=True,
+        extra="ignore",
+        ser_json_bytes="base64",
+        val_json_bytes="base64",
+    )
+
+
+class GateEvent(AbstractEvent):
+    kind: Literal["Gate"] = "Gate"
+    qubits: list[int] = Field(default_factory=list)
+    gate_name: str
+    params: list[float] = Field(default_factory=list)
+    predicates: list[PredicateResult] = Field(default_factory=list)
+
+
+class MeasurementEvent(AbstractEvent):
+    kind: Literal["Measurement"] = "Measurement"
+    qubit: int
+
+
+class ResetEvent(AbstractEvent):
+    kind: Literal["Reset"] = "Reset"
+    qubit: int
+
+
+class CustomEvent(AbstractEvent):
+    kind: Literal["Custom"] = "Custom"
+    tag: int
+    data: bytes
+
+
+Event = Annotated[
+    Union[GateEvent, MeasurementEvent, ResetEvent, CustomEvent],
+    Field(discriminator="kind"),
+]
+Source = Annotated[
+    Union[UserProgramSource, RuntimeSource],
+    Field(discriminator="kind"),
+]
+
+
+class EventRecord(BaseModel):
+    source: Source
+    event: Event
+
+
+class Trace(BaseModel):
+    events: list[EventRecord] = Field(default_factory=list)
+
+    def add_runtime_event(
+        self, event: AbstractEvent, start_time_ns: int, end_time_ns: int
+    ):
+        self.events.append(
+            EventRecord(
+                source=RuntimeSource(
+                    start_time=start_time_ns,
+                    end_time=end_time_ns,
+                ),
+                event=event,
+            )
+        )
+
+    def add_user_program_event(self, event: AbstractEvent, index: int):
+        self.events.append(
+            EventRecord(
+                source=UserProgramSource(index=index),
+                event=event,
+            )
+        )

--- a/selene-core/python/selene_core/trace.py
+++ b/selene-core/python/selene_core/trace.py
@@ -51,10 +51,28 @@ class ResetEvent(AbstractEvent):
     qubit: int
 
 
-class CustomEvent(AbstractEvent):
-    kind: Literal["Custom"] = "Custom"
+class OpaquePayload(AbstractEvent):
+    kind: Literal["OpaquePayload"] = "OpaquePayload"
     tag: int
     data: bytes
+
+
+class KeyValuePairPayload(AbstractEvent):
+    kind: Literal["KeyValuePairPayload"] = "KeyValuePairPayload"
+    data: dict[
+        str, str | int | float | bool | list[int] | list[float] | list[str] | list[bool]
+    ]
+
+
+CustomPayload = Annotated[
+    Union[OpaquePayload, KeyValuePairPayload],
+    Field(discriminator="kind"),
+]
+
+
+class CustomEvent(AbstractEvent):
+    kind: Literal["Custom"] = "Custom"
+    payload: CustomPayload
 
 
 Event = Annotated[
@@ -99,6 +117,16 @@ class Trace(BaseModel):
 
     def strip_custom_events(self) -> "Trace":
         return self.filter(lambda r: not isinstance(r.event, CustomEvent))
+
+    def strip_opaque_custom_events(self) -> "Trace":
+        return self.filter(
+            lambda r: (
+                not (
+                    isinstance(r.event, CustomEvent)
+                    and isinstance(r.event.payload, OpaquePayload)
+                )
+            )
+        )
 
     def get_runtime_trace(self) -> "Trace":
         return self.filter(lambda e: isinstance(e.source, RuntimeSource))

--- a/selene-core/python/selene_core/trace.py
+++ b/selene-core/python/selene_core/trace.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal, Union, Callable
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -95,3 +95,12 @@ class Trace(BaseModel):
                 event=event,
             )
         )
+
+    def filter(self, predicate: Callable[[EventRecord], bool]) -> list[EventRecord]:
+        return Trace(events=list(filter(predicate, self.events)))
+
+    def get_runtime_trace(self) -> list[EventRecord]:
+        return self.filter(lambda e: isinstance(e.source, RuntimeSource))
+
+    def get_user_program_trace(self) -> list[EventRecord]:
+        return self.filter(lambda e: isinstance(e.source, UserProgramSource))

--- a/selene-core/python/selene_core/trace.py
+++ b/selene-core/python/selene_core/trace.py
@@ -75,9 +75,7 @@ class EventRecord(BaseModel):
 class Trace(BaseModel):
     events: list[EventRecord] = Field(default_factory=list)
 
-    def add_runtime_event(
-        self, event: AbstractEvent, start_time_ns: int, end_time_ns: int
-    ):
+    def add_runtime_event(self, event: Event, start_time_ns: int, end_time_ns: int):
         self.events.append(
             EventRecord(
                 source=RuntimeSource(
@@ -88,7 +86,7 @@ class Trace(BaseModel):
             )
         )
 
-    def add_user_program_event(self, event: AbstractEvent, index: int):
+    def add_user_program_event(self, event: Event, index: int):
         self.events.append(
             EventRecord(
                 source=UserProgramSource(index=index),
@@ -96,14 +94,14 @@ class Trace(BaseModel):
             )
         )
 
-    def filter(self, predicate: Callable[[EventRecord], bool]) -> list[EventRecord]:
+    def filter(self, predicate: Callable[[EventRecord], bool]) -> "Trace":
         return Trace(events=list(filter(predicate, self.events)))
 
-    def strip_custom_events(self) -> list[EventRecord]:
+    def strip_custom_events(self) -> "Trace":
         return self.filter(lambda r: not isinstance(r.event, CustomEvent))
 
-    def get_runtime_trace(self) -> list[EventRecord]:
+    def get_runtime_trace(self) -> "Trace":
         return self.filter(lambda e: isinstance(e.source, RuntimeSource))
 
-    def get_user_program_trace(self) -> list[EventRecord]:
+    def get_user_program_trace(self) -> "Trace":
         return self.filter(lambda e: isinstance(e.source, UserProgramSource))

--- a/selene-core/python/selene_core/trace.py
+++ b/selene-core/python/selene_core/trace.py
@@ -99,6 +99,9 @@ class Trace(BaseModel):
     def filter(self, predicate: Callable[[EventRecord], bool]) -> list[EventRecord]:
         return Trace(events=list(filter(predicate, self.events)))
 
+    def strip_custom_events(self) -> list[EventRecord]:
+        return self.filter(lambda r: not isinstance(r.event, CustomEvent))
+
     def get_runtime_trace(self) -> list[EventRecord]:
         return self.filter(lambda e: isinstance(e.source, RuntimeSource))
 

--- a/selene-core/python/selene_core/trace.py
+++ b/selene-core/python/selene_core/trace.py
@@ -37,7 +37,7 @@ class GateEvent(AbstractEvent):
     kind: Literal["Gate"] = "Gate"
     qubits: list[int] = Field(default_factory=list)
     gate_name: str
-    params: list[float] = Field(default_factory=list)
+    params: list[float | int | bool] = Field(default_factory=list)
     predicates: list[PredicateResult] = Field(default_factory=list)
 
 

--- a/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_1.json
+++ b/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_1.json
@@ -1,0 +1,2575 @@
+{
+  "events": [
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 0
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 1
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 2
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 3
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 4
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 5
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 6
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 7
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 8
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 9
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 10
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 11
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 12
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 13
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 14
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 15
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 16
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 17
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 18
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 19
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 20
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 21
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 22
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 23
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 24
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 25
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 26
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 27
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 28
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 29
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 30
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          1
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 31
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 32
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 33
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 34
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 35
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 36
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 37
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 38
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 39
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 40
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 41
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 42
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 43
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 44
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 45
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 46
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 47
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 48
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 49
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 50
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 51
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 52
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 53
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 54
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 55
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 56
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 57
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 58
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 59
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 60
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 61
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 62
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 63
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 64
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 65
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 66
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 67
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 68
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 69
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 70
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 71
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 72
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 73
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 74
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 75
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 76
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 77
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 78
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 79
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 80
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 81
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 82
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 83
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 84
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.02454369260617026
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 85
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.02454369260617026
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 86
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 87
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 88
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 89
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 90
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 91
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 92
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 93
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 94
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 95
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 96
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 97
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 98
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 99
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 100
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 101
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 102
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 103
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 104
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 105
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 106
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 500000,
+        "end_time": 1000000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 1000000,
+        "end_time": 1500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 1500000,
+        "end_time": 2000000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 2000000,
+        "end_time": 2500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 2500000,
+        "end_time": 3000000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 3000000,
+        "end_time": 3500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 3500000,
+        "end_time": 4000000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 4000000,
+        "end_time": 5200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 5200000,
+        "end_time": 7700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 7700000,
+        "end_time": 10200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 10200000,
+        "end_time": 12700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 12700000,
+        "end_time": 15200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 15200000,
+        "end_time": 17700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 17700000,
+        "end_time": 20200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 20200000,
+        "end_time": 22700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          1
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 22700000,
+        "end_time": 23900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 23900000,
+        "end_time": 26400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 26400000,
+        "end_time": 28900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 28900000,
+        "end_time": 31400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 31400000,
+        "end_time": 33900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 33900000,
+        "end_time": 36400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 36400000,
+        "end_time": 38900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 38900000,
+        "end_time": 40100000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 40100000,
+        "end_time": 42600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 42600000,
+        "end_time": 45100000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 45100000,
+        "end_time": 47600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 47600000,
+        "end_time": 50100000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 50100000,
+        "end_time": 52600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 52600000,
+        "end_time": 53800000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 53800000,
+        "end_time": 56300000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 56300000,
+        "end_time": 58800000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 58800000,
+        "end_time": 61300000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 61300000,
+        "end_time": 63800000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 63800000,
+        "end_time": 65000000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 65000000,
+        "end_time": 67500000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 67500000,
+        "end_time": 70000000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 70000000,
+        "end_time": 72500000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 72500000,
+        "end_time": 73700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 73700000,
+        "end_time": 76200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 76200000,
+        "end_time": 78700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 78700000,
+        "end_time": 79900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 79900000,
+        "end_time": 82400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 82400000,
+        "end_time": 83600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 83600000,
+        "end_time": 84800000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 84800000,
+        "end_time": 87800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 107
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 87800000,
+        "end_time": 90800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 108
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 90800000,
+        "end_time": 93800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 109
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 93800000,
+        "end_time": 96800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 110
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 96800000,
+        "end_time": 99800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 111
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 99800000,
+        "end_time": 102800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 112
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 102800000,
+        "end_time": 105800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 113
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 105800000,
+        "end_time": 108800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 7
+      }
+    }
+  ]
+}

--- a/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_1.json
+++ b/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_1.json
@@ -1805,7 +1805,10 @@
           0
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1822,7 +1825,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1839,7 +1844,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1856,7 +1863,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1873,7 +1882,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1890,7 +1901,9 @@
           3
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1907,7 +1920,9 @@
           2
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1924,7 +1939,9 @@
           1
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1940,7 +1957,10 @@
           1
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -3.141592653589793
+        ],
         "predicates": []
       }
     },
@@ -1957,7 +1977,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -1974,7 +1996,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -1991,7 +2015,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2008,7 +2034,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2025,7 +2053,9 @@
           3
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2042,7 +2072,9 @@
           2
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2058,7 +2090,10 @@
           2
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -3.9269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2075,7 +2110,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2092,7 +2129,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2109,7 +2148,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2126,7 +2167,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2143,7 +2186,9 @@
           3
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2159,7 +2204,10 @@
           3
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.319689898685965
+        ],
         "predicates": []
       }
     },
@@ -2176,7 +2224,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2193,7 +2243,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2210,7 +2262,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2227,7 +2281,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2243,7 +2299,10 @@
           4
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.516039439535327
+        ],
         "predicates": []
       }
     },
@@ -2260,7 +2319,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.09817477042468103
+        ],
         "predicates": []
       }
     },
@@ -2277,7 +2338,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.09817477042468103
+        ],
         "predicates": []
       }
     },
@@ -2294,7 +2357,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.09817477042468103
+        ],
         "predicates": []
       }
     },
@@ -2310,7 +2375,10 @@
           5
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.614214209960009
+        ],
         "predicates": []
       }
     },
@@ -2327,7 +2395,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.04908738521234052
+        ],
         "predicates": []
       }
     },
@@ -2344,7 +2414,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.04908738521234052
+        ],
         "predicates": []
       }
     },
@@ -2360,7 +2432,10 @@
           6
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.663301595172349
+        ],
         "predicates": []
       }
     },
@@ -2377,7 +2452,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.02454369260617026
+        ],
         "predicates": []
       }
     },
@@ -2393,7 +2470,10 @@
           7
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.687845287778519
+        ],
         "predicates": []
       }
     },
@@ -2409,7 +2489,10 @@
           7
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -7.829437941368312
+        ],
         "predicates": []
       }
     },

--- a/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_2.json
+++ b/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_2.json
@@ -1,0 +1,2575 @@
+{
+  "events": [
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 0
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 1
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 2
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 3
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 4
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 5
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 6
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 7
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 8
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 9
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 10
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 11
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 12
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 13
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 14
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 15
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 16
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 17
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 18
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 19
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 20
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 21
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 22
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 23
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 24
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 25
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 26
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 27
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 28
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 29
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 30
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          1
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 31
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 32
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 33
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 34
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 35
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 36
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 37
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 38
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 39
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 40
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 41
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 42
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 43
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 44
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 45
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 46
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 47
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 48
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 49
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 50
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 51
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 52
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 53
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 54
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 55
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 56
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 57
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 58
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 59
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 60
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 61
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 62
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 63
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 64
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 65
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 66
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 67
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 68
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 69
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 70
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 71
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 72
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 73
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 74
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 75
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 76
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 77
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 78
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 79
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 80
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 81
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 82
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 83
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 84
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.02454369260617026
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 85
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.02454369260617026
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 86
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 87
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 88
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 89
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 90
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 91
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 92
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 93
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 94
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 95
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 96
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 97
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 98
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 99
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 100
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 101
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 102
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 103
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 104
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 105
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 106
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 500000,
+        "end_time": 1000000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 500000,
+        "end_time": 1000000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 1000000,
+        "end_time": 1500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 1000000,
+        "end_time": 1500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 1500000,
+        "end_time": 2000000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 1500000,
+        "end_time": 2000000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 2000000,
+        "end_time": 3200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 3200000,
+        "end_time": 5700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 5700000,
+        "end_time": 8200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 8200000,
+        "end_time": 10700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 10700000,
+        "end_time": 13200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 13200000,
+        "end_time": 15700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 15700000,
+        "end_time": 18200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 18200000,
+        "end_time": 20700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          1
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 20700000,
+        "end_time": 21900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 21900000,
+        "end_time": 24400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 24400000,
+        "end_time": 26900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 26900000,
+        "end_time": 29400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 29400000,
+        "end_time": 31900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 31900000,
+        "end_time": 34400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 34400000,
+        "end_time": 36900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 36900000,
+        "end_time": 38100000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 38100000,
+        "end_time": 40600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 40600000,
+        "end_time": 43100000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 43100000,
+        "end_time": 45600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 45600000,
+        "end_time": 48100000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 48100000,
+        "end_time": 50600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 50600000,
+        "end_time": 51800000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 51800000,
+        "end_time": 54300000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 54300000,
+        "end_time": 56800000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 56800000,
+        "end_time": 59300000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 59300000,
+        "end_time": 61800000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 61800000,
+        "end_time": 63000000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 63000000,
+        "end_time": 65500000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 65500000,
+        "end_time": 68000000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 68000000,
+        "end_time": 70500000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 70500000,
+        "end_time": 71700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 71700000,
+        "end_time": 74200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 74200000,
+        "end_time": 76700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 76700000,
+        "end_time": 77900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 77900000,
+        "end_time": 80400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 80400000,
+        "end_time": 81600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 81600000,
+        "end_time": 82800000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 82800000,
+        "end_time": 85800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 82800000,
+        "end_time": 85800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 107
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 108
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 85800000,
+        "end_time": 88800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 85800000,
+        "end_time": 88800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 109
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 110
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 88800000,
+        "end_time": 91800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 88800000,
+        "end_time": 91800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 111
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 112
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 91800000,
+        "end_time": 94800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 91800000,
+        "end_time": 94800000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 113
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 7
+      }
+    }
+  ]
+}

--- a/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_2.json
+++ b/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_2.json
@@ -1805,7 +1805,10 @@
           0
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1822,7 +1825,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1839,7 +1844,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1856,7 +1863,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1873,7 +1882,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1890,7 +1901,9 @@
           3
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1907,7 +1920,9 @@
           2
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1924,7 +1939,9 @@
           1
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1940,7 +1957,10 @@
           1
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -3.141592653589793
+        ],
         "predicates": []
       }
     },
@@ -1957,7 +1977,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -1974,7 +1996,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -1991,7 +2015,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2008,7 +2034,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2025,7 +2053,9 @@
           3
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2042,7 +2072,9 @@
           2
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2058,7 +2090,10 @@
           2
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -3.9269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2075,7 +2110,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2092,7 +2129,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2109,7 +2148,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2126,7 +2167,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2143,7 +2186,9 @@
           3
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2159,7 +2204,10 @@
           3
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.319689898685965
+        ],
         "predicates": []
       }
     },
@@ -2176,7 +2224,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2193,7 +2243,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2210,7 +2262,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2227,7 +2281,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2243,7 +2299,10 @@
           4
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.516039439535327
+        ],
         "predicates": []
       }
     },
@@ -2260,7 +2319,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.09817477042468103
+        ],
         "predicates": []
       }
     },
@@ -2277,7 +2338,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.09817477042468103
+        ],
         "predicates": []
       }
     },
@@ -2294,7 +2357,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.09817477042468103
+        ],
         "predicates": []
       }
     },
@@ -2310,7 +2375,10 @@
           5
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.614214209960009
+        ],
         "predicates": []
       }
     },
@@ -2327,7 +2395,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.04908738521234052
+        ],
         "predicates": []
       }
     },
@@ -2344,7 +2414,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.04908738521234052
+        ],
         "predicates": []
       }
     },
@@ -2360,7 +2432,10 @@
           6
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.663301595172349
+        ],
         "predicates": []
       }
     },
@@ -2377,7 +2452,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.02454369260617026
+        ],
         "predicates": []
       }
     },
@@ -2393,7 +2470,10 @@
           7
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.687845287778519
+        ],
         "predicates": []
       }
     },
@@ -2409,7 +2489,10 @@
           7
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -7.829437941368312
+        ],
         "predicates": []
       }
     },

--- a/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_8.json
+++ b/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_8.json
@@ -1,0 +1,2575 @@
+{
+  "events": [
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 0
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 1
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 2
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 3
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 4
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 5
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 6
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 7
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 8
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 9
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 10
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 11
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 12
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 13
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 14
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "QAlloc",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 15
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 16
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 17
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 18
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 19
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 20
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 21
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 22
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 23
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 24
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 25
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 26
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 27
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 28
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 29
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 30
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          1
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 31
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rz",
+        "params": [
+          1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 32
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 33
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 34
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 35
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 36
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 37
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 38
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 39
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 40
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 41
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 42
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 43
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 44
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 45
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.7853981633974483
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 46
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 47
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 48
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 49
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 50
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 51
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 52
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 53
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 54
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 55
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 56
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 57
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.39269908169872414
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 58
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 59
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 60
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 61
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 62
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 63
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 64
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 65
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 66
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 67
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.19634954084936207
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 68
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 69
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 70
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 71
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 72
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 73
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 74
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 75
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.09817477042468103
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 76
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 77
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 78
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 79
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 80
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 81
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.04908738521234052
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 82
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 83
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 84
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [
+          -0.02454369260617026
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 85
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          0.02454369260617026
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 86
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 87
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 88
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 89
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rz",
+        "params": [
+          3.141592653589793
+        ],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 90
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 91
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 92
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 93
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 94
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 95
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 96
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 97
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 98
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 99
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 100
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 101
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 102
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 103
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 104
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 105
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "QFree",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 106
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 0,
+        "end_time": 500000
+      },
+      "event": {
+        "kind": "Reset",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 500000,
+        "end_time": 1700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 1700000,
+        "end_time": 4200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 4200000,
+        "end_time": 6700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 6700000,
+        "end_time": 9200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 9200000,
+        "end_time": 11700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 11700000,
+        "end_time": 14200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 14200000,
+        "end_time": 16700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 16700000,
+        "end_time": 19200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          0,
+          1
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 19200000,
+        "end_time": 20400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 20400000,
+        "end_time": 22900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 22900000,
+        "end_time": 25400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 25400000,
+        "end_time": 27900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 27900000,
+        "end_time": 30400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 30400000,
+        "end_time": 32900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 32900000,
+        "end_time": 35400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          1,
+          2
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 35400000,
+        "end_time": 36600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 36600000,
+        "end_time": 39100000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 39100000,
+        "end_time": 41600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 41600000,
+        "end_time": 44100000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 44100000,
+        "end_time": 46600000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 46600000,
+        "end_time": 49100000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          2,
+          3
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 49100000,
+        "end_time": 50300000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 50300000,
+        "end_time": 52800000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 52800000,
+        "end_time": 55300000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 55300000,
+        "end_time": 57800000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 57800000,
+        "end_time": 60300000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          3,
+          4
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 60300000,
+        "end_time": 61500000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 61500000,
+        "end_time": 64000000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 64000000,
+        "end_time": 66500000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 66500000,
+        "end_time": 69000000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          4,
+          5
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 69000000,
+        "end_time": 70200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 70200000,
+        "end_time": 72700000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 72700000,
+        "end_time": 75200000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          5,
+          6
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 75200000,
+        "end_time": 76400000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 76400000,
+        "end_time": 78900000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          6,
+          7
+        ],
+        "gate_name": "Rzz",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 78900000,
+        "end_time": 80100000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 80100000,
+        "end_time": 81300000
+      },
+      "event": {
+        "kind": "Gate",
+        "qubits": [
+          7
+        ],
+        "gate_name": "Rxy",
+        "params": [],
+        "predicates": []
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 81300000,
+        "end_time": 84300000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 0
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 81300000,
+        "end_time": 84300000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 81300000,
+        "end_time": 84300000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 81300000,
+        "end_time": 84300000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 81300000,
+        "end_time": 84300000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 81300000,
+        "end_time": 84300000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 81300000,
+        "end_time": 84300000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "Runtime",
+        "start_time": 81300000,
+        "end_time": 84300000
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 7
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 107
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 1
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 108
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 2
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 109
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 3
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 110
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 4
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 111
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 5
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 112
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 6
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 113
+      },
+      "event": {
+        "kind": "Measurement",
+        "qubit": 7
+      }
+    }
+  ]
+}

--- a/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_8.json
+++ b/selene-ext/runtimes/soft_rz/python/tests/snapshots/test_batching/test_batching_behaviour/trace_batching_8.json
@@ -1805,7 +1805,10 @@
           0
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1822,7 +1825,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1839,7 +1844,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1856,7 +1863,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1873,7 +1882,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1890,7 +1901,9 @@
           3
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1907,7 +1920,9 @@
           2
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1924,7 +1939,9 @@
           1
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -1.5707963267948966
+        ],
         "predicates": []
       }
     },
@@ -1940,7 +1957,10 @@
           1
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -3.141592653589793
+        ],
         "predicates": []
       }
     },
@@ -1957,7 +1977,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -1974,7 +1996,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -1991,7 +2015,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2008,7 +2034,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2025,7 +2053,9 @@
           3
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2042,7 +2072,9 @@
           2
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.7853981633974483
+        ],
         "predicates": []
       }
     },
@@ -2058,7 +2090,10 @@
           2
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -3.9269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2075,7 +2110,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2092,7 +2129,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2109,7 +2148,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2126,7 +2167,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2143,7 +2186,9 @@
           3
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.39269908169872414
+        ],
         "predicates": []
       }
     },
@@ -2159,7 +2204,10 @@
           3
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.319689898685965
+        ],
         "predicates": []
       }
     },
@@ -2176,7 +2224,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2193,7 +2243,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2210,7 +2262,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2227,7 +2281,9 @@
           4
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.19634954084936207
+        ],
         "predicates": []
       }
     },
@@ -2243,7 +2299,10 @@
           4
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.516039439535327
+        ],
         "predicates": []
       }
     },
@@ -2260,7 +2319,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.09817477042468103
+        ],
         "predicates": []
       }
     },
@@ -2277,7 +2338,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.09817477042468103
+        ],
         "predicates": []
       }
     },
@@ -2294,7 +2357,9 @@
           5
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.09817477042468103
+        ],
         "predicates": []
       }
     },
@@ -2310,7 +2375,10 @@
           5
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.614214209960009
+        ],
         "predicates": []
       }
     },
@@ -2327,7 +2395,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.04908738521234052
+        ],
         "predicates": []
       }
     },
@@ -2344,7 +2414,9 @@
           6
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.04908738521234052
+        ],
         "predicates": []
       }
     },
@@ -2360,7 +2432,10 @@
           6
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.663301595172349
+        ],
         "predicates": []
       }
     },
@@ -2377,7 +2452,9 @@
           7
         ],
         "gate_name": "Rzz",
-        "params": [],
+        "params": [
+          -0.02454369260617026
+        ],
         "predicates": []
       }
     },
@@ -2393,7 +2470,10 @@
           7
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -4.687845287778519
+        ],
         "predicates": []
       }
     },
@@ -2409,7 +2489,10 @@
           7
         ],
         "gate_name": "Rxy",
-        "params": [],
+        "params": [
+          1.5707963267948966,
+          -7.829437941368312
+        ],
         "predicates": []
       }
     },

--- a/selene-ext/runtimes/soft_rz/python/tests/test_batching.py
+++ b/selene-ext/runtimes/soft_rz/python/tests/test_batching.py
@@ -2,7 +2,7 @@ from textwrap import dedent
 import json
 
 from selene_sim.build import build
-from selene_sim import Quest, SoftRZRuntime
+from selene_sim.backends import Quest, SoftRZRuntime
 from selene_sim.event_hooks import MetricStore, CircuitExtractor, MultiEventHook
 
 
@@ -98,4 +98,9 @@ def test_batching_behaviour(snapshot, compiled_guppy):
         snapshot.assert_match(
             json.dumps(format_friendly, indent=2),
             f"instructions_batching_{batching}.json",
+        )
+        trace = output_instructions.get_trace()
+        snapshot.assert_match(
+            trace.model_dump_json(indent=2),
+            f"trace_batching_{batching}.json",
         )

--- a/selene-sim/python/selene_sim/event_hooks/instruction_log.py
+++ b/selene-sim/python/selene_sim/event_hooks/instruction_log.py
@@ -582,35 +582,49 @@ class ShotInstructions:
                         start_time_ns = start
                         end_time_ns = start + duration
                     case Reset(qubit=qubit):
-                        event = ResetEvent(qubit=qubit)
-                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
+                        trace.add_runtime_event(
+                            ResetEvent(qubit=qubit), start_time_ns, end_time_ns
+                        )
                     case FutureRead(qubit=qubit):
-                        event = MeasurementEvent(qubit=qubit)
-                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
+                        trace.add_runtime_event(
+                            MeasurementEvent(qubit=qubit), start_time_ns, end_time_ns
+                        )
                     case Rxy(qubit=qubit, theta=theta, phi=phi):
-                        event = GateEvent(
-                            gate_name="Rxy",
-                            qubits=[qubit],
-                            params=[theta, phi],
+                        trace.add_runtime_event(
+                            GateEvent(
+                                gate_name="Rxy",
+                                qubits=[qubit],
+                                params=[theta, phi],
+                            ),
+                            start_time_ns,
+                            end_time_ns,
                         )
-                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
                     case Rz(qubit=qubit, theta=theta):
-                        event = GateEvent(
-                            gate_name="Rz",
-                            qubits=[qubit],
-                            params=[theta],
+                        trace.add_runtime_event(
+                            GateEvent(
+                                gate_name="Rz",
+                                qubits=[qubit],
+                                params=[theta],
+                            ),
+                            start_time_ns,
+                            end_time_ns,
                         )
-                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
                     case Rzz(qubit0=qubit0, qubit1=qubit1, theta=theta):
-                        event = GateEvent(
-                            gate_name="Rzz",
-                            qubits=[qubit0, qubit1],
-                            params=[theta],
+                        trace.add_runtime_event(
+                            GateEvent(
+                                gate_name="Rzz",
+                                qubits=[qubit0, qubit1],
+                                params=[theta],
+                            ),
+                            start_time_ns,
+                            end_time_ns,
                         )
-                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
                     case CustomOperation(tag=tag, data=data):
-                        event = CustomEvent(payload=OpaquePayload(tag=tag, data=data))
-                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
+                        trace.add_runtime_event(
+                            CustomEvent(payload=OpaquePayload(tag=tag, data=data)),
+                            start_time_ns,
+                            end_time_ns,
+                        )
                     case _:
                         pass
         return trace

--- a/selene-sim/python/selene_sim/event_hooks/instruction_log.py
+++ b/selene-sim/python/selene_sim/event_hooks/instruction_log.py
@@ -20,6 +20,7 @@ from selene_core.trace import (
     GateEvent,
     MeasurementEvent,
     ResetEvent,
+    OpaquePayload,
     CustomEvent,
 )
 
@@ -468,7 +469,7 @@ class ShotInstructions:
                 match instruction.operation:
                     case CustomOperation(tag=tag, data=data):
                         trace.add_user_program_event(
-                            CustomEvent(tag=tag, data=data),
+                            CustomEvent(payload=OpaquePayload(tag=tag, data=data)),
                             index=user_program_event_index,
                         )
                         user_program_event_index += 1
@@ -610,7 +611,7 @@ class ShotInstructions:
                         )
                         trace.add_runtime_event(event, start_time_ns, end_time_ns)
                     case CustomOperation(tag=tag, data=data):
-                        event = CustomEvent(tag=tag, data=data)
+                        event = CustomEvent(payload=OpaquePayload(tag=tag, data=data))
                         trace.add_runtime_event(event, start_time_ns, end_time_ns)
                     case _:
                         pass

--- a/selene-sim/python/selene_sim/event_hooks/instruction_log.py
+++ b/selene-sim/python/selene_sim/event_hooks/instruction_log.py
@@ -575,6 +575,7 @@ class ShotInstructions:
                             ),
                             index=user_program_event_index,
                         )
+                        user_program_event_index += 1
             if instruction.source == Source.OPTIMISER:
                 match instruction.operation:
                     case BatchStart(start_time_ns=start, duration_ns=duration):

--- a/selene-sim/python/selene_sim/event_hooks/instruction_log.py
+++ b/selene-sim/python/selene_sim/event_hooks/instruction_log.py
@@ -15,6 +15,14 @@ from collections.abc import Iterator
 from typing import Any
 import math
 
+from selene_core.trace import (
+    Trace,
+    GateEvent,
+    MeasurementEvent,
+    ResetEvent,
+    CustomEvent,
+)
+
 from .event_hook import EventHook
 
 PYTKET_AVAILABLE = False
@@ -443,6 +451,170 @@ class ShotInstructions:
     def dump(self) -> None:
         for instruction in self:
             print(f"{instruction.source}: {instruction.operation}")
+
+    def get_trace(self) -> Trace:
+        """
+        Obtain a selene_core.Trace from the instruction log, providing a
+        structured representation of the operations performed by the runtime.
+        This trace may be consumed, analysed, and communicated easily, allowing
+        decoupling of simulation itself from analysis and visualization.
+        """
+        trace = Trace()
+        user_program_event_index = 0
+        start_time_ns = 0
+        end_time_ns = 0
+        for instruction in self:
+            if instruction.source == Source.USER:
+                match instruction.operation:
+                    case CustomOperation(tag=tag, data=data):
+                        trace.add_user_program_event(
+                            CustomEvent(tag=tag, data=data),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case LocalBarrier(qubits=qubits, sleep_time=sleep_time):
+                        trace.add_user_program_event(
+                            GateEvent(
+                                gate_name="LocalBarrier",
+                                qubits=qubits,
+                                params=[sleep_time],
+                            ),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case GlobalBarrier(sleep_time=sleep_time):
+                        trace.add_user_program_event(
+                            GateEvent(
+                                gate_name="GlobalBarrier",
+                                qubits=[],
+                                params=[sleep_time],
+                            ),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case QAlloc(qubit=qubit):
+                        trace.add_user_program_event(
+                            GateEvent(
+                                gate_name="QAlloc",
+                                qubits=[qubit],
+                                params=[],
+                            ),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case QFree(qubit=qubit):
+                        trace.add_user_program_event(
+                            GateEvent(
+                                gate_name="QFree",
+                                qubits=[qubit],
+                                params=[],
+                            ),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case Rxy(qubit=qubit, theta=theta, phi=phi):
+                        trace.add_user_program_event(
+                            GateEvent(
+                                gate_name="Rxy",
+                                qubits=[qubit],
+                                params=[theta, phi],
+                            ),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case Rzz(qubit0=qubit0, qubit1=qubit1, theta=theta):
+                        trace.add_user_program_event(
+                            GateEvent(
+                                gate_name="Rzz",
+                                qubits=[qubit0, qubit1],
+                                params=[theta],
+                            ),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case Rz(qubit=qubit, theta=theta):
+                        trace.add_user_program_event(
+                            GateEvent(
+                                gate_name="Rz",
+                                qubits=[qubit],
+                                params=[theta],
+                            ),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case Reset(qubit=qubit):
+                        trace.add_user_program_event(
+                            ResetEvent(qubit=qubit), index=user_program_event_index
+                        )
+                        user_program_event_index += 1
+                    case MeasureRequest(qubit=qubit):
+                        trace.add_user_program_event(
+                            MeasurementEvent(qubit=qubit),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case MeasureLeakedRequest(qubit=qubit):
+                        trace.add_user_program_event(
+                            MeasurementEvent(qubit=qubit),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case FutureRead(qubit=qubit):
+                        trace.add_user_program_event(
+                            MeasurementEvent(qubit=qubit),
+                            index=user_program_event_index,
+                        )
+                        user_program_event_index += 1
+                    case ClassicalDelay(duration_ns=duration_ns):
+                        trace.add_user_program_event(
+                            event=GateEvent(
+                                gate_name="ClassicalDelay",
+                                qubits=[],
+                                params=[duration_ns],
+                            ),
+                            index=user_program_event_index,
+                        )
+            if instruction.source == Source.OPTIMISER:
+                match instruction.operation:
+                    case BatchStart(start_time_ns=start, duration_ns=duration):
+                        start_time_ns = start
+                        end_time_ns = start + duration
+                    case Reset(qubit=qubit):
+                        event = ResetEvent(qubit=qubit)
+                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
+                    case FutureRead(qubit=qubit):
+                        event = MeasurementEvent(qubit=qubit)
+                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
+                    case Rxy(qubit=qubit, theta=theta, phi=phi):
+                        event = GateEvent(
+                            gate_name="Rxy",
+                            qubits=[qubit],
+                            args={
+                                "theta": theta,
+                                "phi": phi,
+                            },
+                        )
+                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
+                    case Rz(qubit=qubit, theta=theta):
+                        event = GateEvent(
+                            gate_name="Rz",
+                            qubits=[qubit],
+                            args={"theta": theta},
+                        )
+                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
+                    case Rzz(qubit0=qubit0, qubit1=qubit1, theta=theta):
+                        event = GateEvent(
+                            gate_name="Rzz",
+                            qubits=[qubit0, qubit1],
+                            args={"theta": theta},
+                        )
+                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
+                    case CustomOperation(tag=tag, data=data):
+                        event = CustomEvent(tag=tag, data=data)
+                        trace.add_runtime_event(event, start_time_ns, end_time_ns)
+                    case _:
+                        pass
+        return trace
 
 
 class CircuitExtractor(EventHook):

--- a/selene-sim/python/selene_sim/event_hooks/instruction_log.py
+++ b/selene-sim/python/selene_sim/event_hooks/instruction_log.py
@@ -591,24 +591,21 @@ class ShotInstructions:
                         event = GateEvent(
                             gate_name="Rxy",
                             qubits=[qubit],
-                            args={
-                                "theta": theta,
-                                "phi": phi,
-                            },
+                            params=[theta, phi],
                         )
                         trace.add_runtime_event(event, start_time_ns, end_time_ns)
                     case Rz(qubit=qubit, theta=theta):
                         event = GateEvent(
                             gate_name="Rz",
                             qubits=[qubit],
-                            args={"theta": theta},
+                            params=[theta],
                         )
                         trace.add_runtime_event(event, start_time_ns, end_time_ns)
                     case Rzz(qubit0=qubit0, qubit1=qubit1, theta=theta):
                         event = GateEvent(
                             gate_name="Rzz",
                             qubits=[qubit0, qubit1],
-                            args={"theta": theta},
+                            params=[theta],
                         )
                         trace.add_runtime_event(event, start_time_ns, end_time_ns)
                     case CustomOperation(tag=tag, data=data):

--- a/uv.lock
+++ b/uv.lock
@@ -843,10 +843,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/a7/8c4f86c78ec03db954d05fd9c57a114cc3a172a2d3e4a8b949cd5ff89471/patchelf-0.17.2.4-py3-none-macosx_10_9_universal2.whl", hash = "sha256:343bb1b94e959f9070ca9607453b04390e36bbaa33c88640b989cefad0aa049e", size = 184436, upload-time = "2025-07-23T21:16:20.578Z" },
     { url = "https://files.pythonhosted.org/packages/7e/19/f7821ef31aab01fa7dc8ebe697ece88ec4f7a0fdd3155dab2dfee4b00e5c/patchelf-0.17.2.4-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:d9b35ebfada70c02679ad036407d9724ffe1255122ba4ac5e4be5868618a5689", size = 482846, upload-time = "2025-07-23T21:16:23.73Z" },
     { url = "https://files.pythonhosted.org/packages/d1/50/107fea848ecfd851d473b079cab79107487d72c4c3cdb25b9d2603a24ca2/patchelf-0.17.2.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:2931a1b5b85f3549661898af7bf746afbda7903c7c9a967cfc998a3563f84fad", size = 477811, upload-time = "2025-07-23T21:16:25.145Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a9/a9a2103e159fd65bffbc21ecc5c8c36e44eb34fe53b4ef85fb6d08c2a635/patchelf-0.17.2.4-py3-none-manylinux2014_armv7l.manylinux_2_17_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:ae44cb3c857d50f54b99e5697aa978726ada33a8a6129d4b8b7ffd28b996652d", size = 431226, upload-time = "2025-07-23T21:16:26.765Z" },
-    { url = "https://files.pythonhosted.org/packages/87/93/897d612f6df7cfd987bdf668425127efeff8d8e4ad8bfbab1c69d2a0d861/patchelf-0.17.2.4-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:680a266a70f60a7a4f4c448482c5bdba80cc8e6bb155a49dcc24238ba49927b0", size = 540276, upload-time = "2025-07-23T21:16:27.983Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/b8/2b92d11533482bac9ee989081d6880845287751b5f528adbd6bb27667fbd/patchelf-0.17.2.4-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.musllinux_1_1_s390x.whl", hash = "sha256:d842b51f0401460f3b1f3a3a67d2c266a8f515a5adfbfa6e7b656cb3ac2ed8bc", size = 596632, upload-time = "2025-07-23T21:16:29.253Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e2/975d4bdb418f942b53e6187b95bd9e0d5e0488b7bc214685a1e43e2c2751/patchelf-0.17.2.4-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:7076d9e127230982e20a81a6e2358d3343004667ba510d9f822d4fdee29b0d71", size = 508281, upload-time = "2025-07-23T21:16:30.865Z" },
 ]
 
 [[package]]
@@ -1404,6 +1400,7 @@ dependencies = [
     { name = "llvmlite", version = "0.47.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic" },
     { name = "pydot" },
     { name = "pyyaml" },
     { name = "qir-qis" },
@@ -1418,6 +1415,7 @@ requires-dist = [
     { name = "llvmlite", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = "~=0.47" },
     { name = "llvmlite", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "==0.45.1" },
     { name = "networkx", specifier = ">=2.6,<4" },
+    { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydot", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "qir-qis", specifier = ">=0.1.2,<0.1.4" },


### PR DESCRIPTION
Provides a pydantic trace format for recording events going into, and coming out of, a runtime during a run.

This can be extracted from a CircuitExtractor with `get_trace()`, and then encoded as json. A schema is provided in selene-core's _dist bundle that may be used to validate the json.

The trace can be loaded at a later point via pydantic. This provides a way of analysing the characteristics of a simulated run.