### PR TITLE
fix: unwrap qir bitcode wrappers before qir-qis conversion

### DIFF
--- a/selene-core/python/selene_core/build_utils/builtins/qir.py
+++ b/selene-core/python/selene_core/build_utils/builtins/qir.py
@@ -9,6 +9,12 @@ from ..symbols import get_symbols_from_llvm
 from qir_qis import get_entry_attributes, qir_ll_to_bc, qir_to_qis, validate_qir
 
 
+def _unwrap_bitcode_resource(resource: Any) -> bytes | None:
+    if hasattr(resource, "bitcode"):
+        resource = resource.bitcode
+    return resource if isinstance(resource, bytes) else None
+
+
 def _matches_qir_ir(text: str) -> bool:
     try:
         symbols = get_symbols_from_llvm(text)
@@ -80,9 +86,8 @@ class QIRBitcodeStringKind(ArtifactKind):
 
     @classmethod
     def matches(cls, resource: Any) -> bool:
-        if hasattr(resource, "bitcode"):
-            resource = resource.bitcode
-        if not isinstance(resource, bytes):
+        resource = _unwrap_bitcode_resource(resource)
+        if resource is None:
             return False
         return _matches_qir_bitcode(resource)
 
@@ -195,8 +200,10 @@ class QIRBitcodeStringToHeliosBitcodeStringStep(Step):
 
     @classmethod
     def apply(cls, build_ctx: BuildCtx, input_artifact: Artifact) -> Artifact:
-        validate_qir(input_artifact.resource)
-        result = qir_to_qis(input_artifact.resource)
+        bitcode = _unwrap_bitcode_resource(input_artifact.resource)
+        assert bitcode is not None, "QIR bitcode step received a non-bitcode resource"
+        validate_qir(bitcode)
+        result = qir_to_qis(bitcode)
         return cls._make_artifact(result)
 
 

--- a/selene-sim/python/tests/test_build_classification.py
+++ b/selene-sim/python/tests/test_build_classification.py
@@ -1,8 +1,14 @@
+from pathlib import Path
+
 from qir_qis import qir_ll_to_bc, qir_to_qis
 
 from selene_core.build_utils import DEFAULT_BUILD_PLANNER
 from selene_core.build_utils.builtins.helios import HeliosLLVMBitcodeStringKind
 from selene_core.build_utils.builtins.qir import QIRBitcodeStringKind
+from selene_sim.build import BitcodeString, build
+
+RESOURCE_DIR = Path(__file__).parent / "resources"
+QIR_RESOURCE_DIR = RESOURCE_DIR / "qir"
 
 
 LLVM_IR = """
@@ -43,3 +49,19 @@ def test_helios_shape_wins_even_if_stale_qir_entrypoint_metadata_remains(monkeyp
 
     assert not QIRBitcodeStringKind.matches(qis_bc)
     assert DEFAULT_BUILD_PLANNER.identify_kind(qis_bc) is HeliosLLVMBitcodeStringKind
+
+
+def test_qir_bitcode_wrapper_builds():
+    qir_bc = qir_ll_to_bc((QIR_RESOURCE_DIR / "adaptive_cond_loop.ll").read_text())
+
+    runner = build(BitcodeString(qir_bc))
+
+    assert runner is not None
+
+
+def test_translated_qis_bitcode_wrapper_builds():
+    qis_bc = qir_to_qis(qir_ll_to_bc(LLVM_IR))
+
+    runner = build(BitcodeString(qis_bc))
+
+    assert runner is not None


### PR DESCRIPTION
## Summary
- unwrap wrapped QIR bitcode before passing it to `qir_qis`
- preserve compatibility for plain `bytes` and LLVM IR text inputs
- add Selene-side regressions for wrapped QIR and wrapped lowered-QIS inputs

## Root Cause
`QIRBitcodeStringKind` accepted wrapper-style inputs with a `.bitcode` attribute, but the QIR-to-Helios step still passed the wrapper object itself into `validate_qir(...)` and `qir_to_qis(...)`. That made `build(BitcodeString(qir_bc))` fail even though the same artifact worked as plain `bytes`.

## Source Of Regression
This behavior was introduced in PR #114 (`feat: QIR support using QIR-QIS`, commit `70ab294`), which added direct QIR support together with the `BitcodeString`-compatible matcher and the QIR-to-Helios conversion step. The matcher unwrapped `.bitcode`, but the conversion step still forwarded the wrapper object itself into `qir_qis`.

PR #157 is related context but not the introducing change. That patch fixed QIR-vs-Helios classification for lowered `qir-qis` output; it did not address this wrapper-handling gap in the QIR conversion step.

## Validation
- `uv run pytest selene-sim/python/tests/test_build_classification.py -q`
- `uv run pytest selene-sim/python/tests/test_qir.py -q`
