### PR TITLE
ci: bump workflow actions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       wheel-ready: ${{ steps.upload_selene_core.outputs.artifact-id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cache selene-core wheel
         id: selene_core_wheel_cache
@@ -37,7 +37,7 @@ jobs:
       #
       # If no cache hit, build selene-core...
       #
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         if: steps.selene_core_wheel_cache.outputs.cache-hit != 'true'
         with:
           path: |
@@ -47,7 +47,7 @@ jobs:
 
       - name: "Set up Python"
         if: steps.selene_core_wheel_cache.outputs.cache-hit != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload selene-core wheel
         id: upload_selene_core
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: selene-core
           path: wheelhouse/selene_core-*.whl
@@ -80,14 +80,13 @@ jobs:
     name: "Selene wheels (${{matrix.os}})"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up UV
         if: ${{ matrix.os != 'ubuntu-latest' }}
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
-          version: "0.6.6"
 
       - name: Prepare cache dir (linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -112,7 +111,7 @@ jobs:
       # --------------------------------
 
       # Cache the rust build intermediates
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             /tmp/ci-cache/selene
@@ -123,10 +122,10 @@ jobs:
 
       # Perform the selene-sim build
       - name: Build selene-sim wheels
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v3.4.1
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: selene-wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
@@ -158,7 +157,7 @@ jobs:
         env:
           SHOULD_RUN: ${{ github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.name)) }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: ${{ steps.check-tag.outputs.run == 'true' }}
         with:
           path: wheelhouse
@@ -166,14 +165,14 @@ jobs:
 
       - name: GH Release
         if: ${{ steps.check-tag.outputs.run == 'true' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ matrix.target.upload }}
           generate_release_notes: true
 
       - name: Setup Python
         if: ${{ steps.check-tag.outputs.run == 'true' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
 

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -22,8 +22,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/cache@v4
+        uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/
@@ -36,8 +36,8 @@ jobs:
       - name: Run rust tests
         run: cargo test --all-features
       # ensure that C interfaces are up to date
-      - uses: extractions/setup-just@v3
-      - uses: cargo-bins/cargo-binstall@v1.15.10
+      - uses: extractions/setup-just@v4
+      - uses: cargo-bins/cargo-binstall@v1.18.1
       - name: Install cbindgen and cargo-expand
         run: |
            cargo binstall cbindgen --no-confirm --version 0.28
@@ -57,4 +57,3 @@ jobs:
             echo "=============================================";
             exit 1;
           fi
-

--- a/.github/workflows/nitpick.yml
+++ b/.github/workflows/nitpick.yml
@@ -25,8 +25,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/cache@v4
+        uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/
@@ -39,10 +39,9 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
-          version: "0.6.6"
       - name: Rust format check
         run: cargo fmt --all -- --check
       - name: Rust lint

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     name: Create release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4.3.0
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.HUGRBOT_PAT }}


### PR DESCRIPTION
## Summary
- bump the GitHub Actions used across the CI workflows to current major versions where available
- remove the explicit `setup-uv` tool-version pin so the workflows stop forcing `uv 0.6.6`
- keep the change scoped to workflow files only

## Notes
- this is intentionally a CI-only maintenance PR
- the most behaviorally relevant changes are the `setup-uv` and `cibuildwheel` bumps; the rest are routine action-version updates
- relates to #165 about enabling automated GitHub Actions updates