### PR TITLE
feat: Use SeleneStartupError for errors before shot_start

### DIFF
--- a/selene-sim/python/selene_sim/result_handling/extract_shot.py
+++ b/selene-sim/python/selene_sim/result_handling/extract_shot.py
@@ -224,7 +224,7 @@ def extract_shot(
         case FullPanicMessage(message=message, code=_):
             # Seeing panics before a shot start is unexpected, and we consider
             # it to either be a misconfiguration or a bug. As such, we raise it
-            # as a runtime error.
+            # as a startup error.
             raise SeleneStartupError(message)
         case other:
             raise SeleneStartupError(f"Unexpected record {other} before shot start")

--- a/selene-sim/python/selene_sim/result_handling/extract_shot.py
+++ b/selene-sim/python/selene_sim/result_handling/extract_shot.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 from ..exceptions import (
     SelenePanicError,
+    SeleneStartupError,
     SeleneRuntimeError,
 )
 
@@ -224,9 +225,9 @@ def extract_shot(
             # Seeing panics before a shot start is unexpected, and we consider
             # it to either be a misconfiguration or a bug. As such, we raise it
             # as a runtime error.
-            raise SeleneRuntimeError(message)
+            raise SeleneStartupError(message)
         case other:
-            raise SeleneRuntimeError(f"Unexpected record {other} before shot start")
+            raise SeleneStartupError(f"Unexpected record {other} before shot start")
 
     # Now we process the rest of the shots.
     for record in records:

--- a/selene-sim/python/tests/test_guppy.py
+++ b/selene-sim/python/tests/test_guppy.py
@@ -10,7 +10,7 @@ from hugr.qsystem.result import QsysResult
 from selene_sim import ClassicalReplay, Coinflip, Quest, Stim, SimpleLeakageErrorModel
 from selene_sim.build import build
 from selene_sim.event_hooks import CircuitExtractor, MetricStore, MeasurementExtractor
-from selene_sim.exceptions import SelenePanicError, SeleneRuntimeError
+from selene_sim.exceptions import SelenePanicError, SeleneStartupError
 
 
 def test_no_results(compiled_guppy):
@@ -616,7 +616,7 @@ def test_corrupted_plugin(compiled_guppy):
     runner = build(llvm_file)
 
     with pytest.raises(
-        SeleneRuntimeError, match=r"Failed to load runtime plugin"
+        SeleneStartupError, match=r"Failed to load runtime plugin"
     ) as exception_info:
         shots = QsysResult(
             runner.run_shots(

--- a/selene-sim/python/tests/test_unparsed.py
+++ b/selene-sim/python/tests/test_unparsed.py
@@ -9,7 +9,6 @@ from selene_sim.event_hooks import MetricStore
 from selene_sim.exceptions import (
     SelenePanicError,
     SeleneStartupError,
-    SeleneRuntimeError,
     SeleneTimeoutError,
 )
 from selene_sim.result_handling.parse_shot import postprocess_unparsed_stream
@@ -407,7 +406,7 @@ def test_memory_allocation_unparsed(compiled_guppy):
             parse_results=False,
         )
     )
-    assert isinstance(error, SeleneRuntimeError)
+    assert isinstance(error, SeleneStartupError)
     assert (
         "It is impossible to describe more than 60 qubits in a statevector on a computer with a 64-bit address space."
         in error.stderr
@@ -475,5 +474,5 @@ def test_corrupted_plugin_unparsed(compiled_guppy):
         )
     )
     assert len(shots) == 0
-    assert isinstance(error, SeleneRuntimeError)
+    assert isinstance(error, SeleneStartupError)
     assert "Failed to load runtime plugin" in error.stderr


### PR DESCRIPTION
When parsing the result stream, we may get errors arising from plugins starting up, e.g. allocation failures. These are presently raised as a SeleneRuntimeError.

While we previously used SeleneStartupError solely for situations in which the backend failed to start up and connect to the fronend, it is reasonable to also include scenarios in which the backend started but failed to load components under this banner.

This helps distinguish situations where the fault is certainly a configuration issue vs those that may be the result of instructions from the user program.