### PR TITLE
chore: release please updates

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,3 +18,4 @@ jobs:
       - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.HUGRBOT_PAT }}
+          target-branch: ${{ github.ref_name }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
   "numpy>=2.2.6",
   "pyyaml>=6.0.2",
-  "selene-core~=0.2.8",
+  "selene-core~=0.2.9", # x-release-please-version
   "selene-hugr-qis-compiler~=0.2.6",
   "tqdm>=4.67.1",
 ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,8 +22,9 @@
                 },
                 {
                     "type": "toml",
-                    "path": "/Cargo.lock",
+                    "path": "/**/Cargo.lock",
                     "jsonpath": "$.package[?(@.name.value=='selene-core')].version"
+                    "glob": true
                 },
                 {
                     "type": "toml",
@@ -31,19 +32,8 @@
                     "jsonpath": "$.package[?(@.name.value=='selene-core')].version"
                 },
                 {
-                    "type": "toml",
-                    "path": "examples/error_model/Cargo.lock",
-                    "jsonpath": "$.package[?(@.name.value=='selene-core')].version"
-                },
-                {
-                    "type": "toml",
-                    "path": "examples/simulator/Cargo.lock",
-                    "jsonpath": "$.package[?(@.name.value=='selene-core')].version"
-                },
-                {
-                    "type": "toml",
-                    "path": "examples/runtime/Cargo.lock",
-                    "jsonpath": "$.package[?(@.name.value=='selene-core')].version"
+                    "type": "generic",
+                    "path": "/pyproject.toml"
                 }
             ]
         },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,7 +23,7 @@
                 {
                     "type": "toml",
                     "path": "/**/Cargo.lock",
-                    "jsonpath": "$.package[?(@.name.value=='selene-core')].version"
+                    "jsonpath": "$.package[?(@.name.value=='selene-core')].version",
                     "glob": true
                 },
                 {


### PR DESCRIPTION
- Globs all Cargo.lock files when updating selene-core, rather than listing them individually
- Keeps selene-sim pinned to the latest selene-core