### PR TITLE
bugfix: Swap backslashes for pipes in ascii linkage diagram

### DIFF
--- a/selene-ext/interfaces/helios_qis/python/selene_helios_qis_plugin/plugin.py
+++ b/selene-ext/interfaces/helios_qis/python/selene_helios_qis_plugin/plugin.py
@@ -19,8 +19,7 @@ function, passing it into the callback.
 | User program | ------ | Static runtime   |
 |              |        |                  |
 ----------------        --------------------
-               \        /
-                \      /
+             |               |
           -----------------------     -------------------------
           |  Dynamic helios-qis |_____| Dynamic base QIS shim |
           |  shim interface     |     |  interface            |


### PR DESCRIPTION
To prevent python warnings about backslashes in comments.