### PR TITLE
ci: Restrict `id-token` OIDC permission to release job

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
### Motivation
- Prevent non-release CI jobs that run checked-out repository build logic from minting GitHub OIDC tokens by removing the workflow-level `id-token: write` grant.

### Description
- Remove `id-token: write` from the workflow-level `permissions` in ` .github/workflows/build_wheels.yml` while leaving the `release` job's `permissions` (which include `id-token: write`) unchanged so the intended publish path retains OIDC capability.

### Testing
- Automated verification printed and inspected ` .github/workflows/build_wheels.yml`, confirmed a single-line removal of the workflow-level `id-token` and that the `release` job still contains `id-token: write`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1306c759e4832289954307cf74d2fd)