### PR TITLE
feat: Permit zero-length arrays in ArgReader. Add argreader_trace_pass.

### DIFF
--- a/selene-ext/utilities/argreader/python/selene_argreader_plugin/__init__.py
+++ b/selene-ext/utilities/argreader/python/selene_argreader_plugin/__init__.py
@@ -1,4 +1,5 @@
 from .plugin import ArgReaderPlugin
 from .provider import ArgProvider, ShotInput
+from .trace_pass import argreader_trace_pass
 
-__all__ = ["ArgReaderPlugin", "ArgProvider", "ShotInput"]
+__all__ = ["ArgReaderPlugin", "ArgProvider", "ShotInput", "argreader_trace_pass"]

--- a/selene-ext/utilities/argreader/python/selene_argreader_plugin/provider.py
+++ b/selene-ext/utilities/argreader/python/selene_argreader_plugin/provider.py
@@ -30,8 +30,6 @@ class ShotInput:
                 raise ValueError(
                     f"All items in the list for key '{key}' must be int, float, or bool"
                 )
-            if isinstance(value, list) and len(value) == 0:
-                raise ValueError(f"List for key '{key}' cannot be empty")
             if not isinstance(key, str):
                 raise ValueError(f"Key '{key}' must be a string")
             if len(key) == 0:

--- a/selene-ext/utilities/argreader/python/selene_argreader_plugin/trace_pass.py
+++ b/selene-ext/utilities/argreader/python/selene_argreader_plugin/trace_pass.py
@@ -1,0 +1,29 @@
+from selene_core import trace
+import yaml
+
+ARGREADER_LOGGING_TAG = 0xA13613EADE130746
+
+
+def argreader_trace_pass(selene_trace: trace.Trace) -> trace.Trace:
+    new_records = []
+    for record in selene_trace.events:
+        if (
+            record.source.kind == "UserProgram"
+            and record.event.kind == "Custom"
+            and record.event.payload.kind == "OpaquePayload"
+            and record.event.payload.tag == ARGREADER_LOGGING_TAG
+        ):
+            yaml_text = record.event.payload.data.decode("utf-8")
+            yaml_data = yaml.safe_load(yaml_text)
+            replacement = trace.EventRecord(
+                source=record.source,
+                event=trace.CustomEvent(
+                    payload=trace.KeyValuePairPayload(
+                        data={"type": "ArgumentRead", **yaml_data}
+                    )
+                ),
+            )
+            new_records.append(replacement)
+        else:
+            new_records.append(record)
+    return trace.Trace(events=new_records)

--- a/selene-ext/utilities/argreader/python/tests/resources/argreader_zero_length_arrays.ll
+++ b/selene-ext/utilities/argreader/python/tests/resources/argreader_zero_length_arrays.ll
@@ -1,0 +1,44 @@
+; ModuleID = 'custom'
+source_filename = "custom"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
+
+; standard QIS
+declare void @setup(i64) local_unnamed_addr
+declare i64 @teardown() local_unnamed_addr
+declare void @print_uint(i8*, i64, i64) local_unnamed_addr
+
+; arg reader plugin functions
+declare void @argreader_get_bool_array(i8*, i8*, i64) local_unnamed_addr
+declare void @argreader_get_u64_array(i8*, i64*, i64) local_unnamed_addr
+declare void @argreader_get_i64_array(i8*, i64*, i64) local_unnamed_addr
+declare void @argreader_get_f64_array(i8*, double*, i64) local_unnamed_addr
+
+@bool_array_label = private constant [17 x i8] c"\10input_bool_array"
+@u64_array_label = private constant [16 x i8] c"\0Finput_u64_array"
+@i64_array_label = private constant [16 x i8] c"\0Finput_i64_array"
+@f64_array_label = private constant [16 x i8] c"\0Finput_f64_array"
+@done_tag = private constant [14 x i8] c"\0DUSER:INT:done"
+
+define private void @main_inner() unnamed_addr {
+alloca_block:
+  call void @argreader_get_bool_array(ptr @bool_array_label, ptr null, i64 0)
+  call void @argreader_get_u64_array(ptr @u64_array_label, ptr null, i64 0)
+  call void @argreader_get_i64_array(ptr @i64_array_label, ptr null, i64 0)
+  call void @argreader_get_f64_array(ptr @f64_array_label, ptr null, i64 0)
+
+  call void @print_uint(ptr @done_tag, i64 0, i64 0)
+  ret void
+}
+
+define i64 @qmain(i64 %0) local_unnamed_addr {
+entry:
+  tail call void @setup(i64 %0)
+  tail call fastcc void @main_inner()
+  %1 = tail call i64 @teardown()
+  ret i64 %1
+}
+
+!name = !{!0}
+
+!0 = !{!"mainlib"}

--- a/selene-ext/utilities/argreader/python/tests/snapshots/test_argreader/test_arg_reader_trace/pass.json
+++ b/selene-ext/utilities/argreader/python/tests/snapshots/test_argreader/test_arg_reader_trace/pass.json
@@ -1,0 +1,164 @@
+{
+  "events": [
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 0
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_bool",
+            "value": true
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 1
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_u64",
+            "value": 2
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 2
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_i64",
+            "value": -4
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 3
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_f64",
+            "value": 0.0125
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 4
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_bool_array",
+            "value": [
+              false,
+              true,
+              true,
+              true,
+              true
+            ]
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 5
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_u64_array",
+            "value": [
+              8,
+              2,
+              5,
+              4,
+              1
+            ]
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 6
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_i64_array",
+            "value": [
+              10,
+              20,
+              15,
+              -25,
+              30
+            ]
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 7
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_f64_array",
+            "value": [
+              0.0,
+              0.125,
+              0.25,
+              0.375,
+              0.5
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/selene-ext/utilities/argreader/python/tests/snapshots/test_argreader/test_arg_reader_zero_length_arrays/pass.json
+++ b/selene-ext/utilities/argreader/python/tests/snapshots/test_argreader/test_arg_reader_zero_length_arrays/pass.json
@@ -1,0 +1,72 @@
+{
+  "events": [
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 0
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_bool_array",
+            "value": []
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 1
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_u64_array",
+            "value": []
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 2
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_i64_array",
+            "value": []
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 3
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "KeyValuePairPayload",
+          "data": {
+            "type": "ArgumentRead",
+            "key": "input_f64_array",
+            "value": []
+          }
+        }
+      }
+    }
+  ]
+}

--- a/selene-ext/utilities/argreader/python/tests/snapshots/test_argreader/test_arg_reader_zero_length_arrays/trace.json
+++ b/selene-ext/utilities/argreader/python/tests/snapshots/test_argreader/test_arg_reader_zero_length_arrays/trace.json
@@ -1,0 +1,60 @@
+{
+  "events": [
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 0
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "OpaquePayload",
+          "tag": 11616494188317837126,
+          "data": "a2V5OiBpbnB1dF9ib29sX2FycmF5CnZhbHVlOiBbXQo="
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 1
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "OpaquePayload",
+          "tag": 11616494188317837126,
+          "data": "a2V5OiBpbnB1dF91NjRfYXJyYXkKdmFsdWU6IFtdCg=="
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 2
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "OpaquePayload",
+          "tag": 11616494188317837126,
+          "data": "a2V5OiBpbnB1dF9pNjRfYXJyYXkKdmFsdWU6IFtdCg=="
+        }
+      }
+    },
+    {
+      "source": {
+        "kind": "UserProgram",
+        "index": 3
+      },
+      "event": {
+        "kind": "Custom",
+        "payload": {
+          "kind": "OpaquePayload",
+          "tag": 11616494188317837126,
+          "data": "a2V5OiBpbnB1dF9mNjRfYXJyYXkKdmFsdWU6IFtdCg=="
+        }
+      }
+    }
+  ]
+}

--- a/selene-ext/utilities/argreader/python/tests/test_argreader.py
+++ b/selene-ext/utilities/argreader/python/tests/test_argreader.py
@@ -5,7 +5,7 @@ import pytest
 from selene_sim import build, Coinflip
 from selene_sim.exceptions import SelenePanicError
 from selene_sim.event_hooks import CircuitExtractor
-from selene_argreader_plugin import ArgReaderPlugin, ArgProvider
+from selene_argreader_plugin import ArgReaderPlugin, ArgProvider, argreader_trace_pass
 
 # Note to avoid confusion:
 # parameter names are configured by the user program, and we
@@ -231,3 +231,38 @@ def test_arg_reader_trace(snapshot):
     trace = extractor.shots[0].get_trace()
     json = trace.model_dump_json(indent=2)
     snapshot.assert_match(json, "trace.json")
+
+    processed_trace = argreader_trace_pass(trace)
+    json = processed_trace.model_dump_json(indent=2)
+    snapshot.assert_match(json, "pass.json")
+
+
+def test_arg_reader_zero_length_arrays(snapshot):
+    llvm_file = Path(__file__).parent / "resources/argreader_zero_length_arrays.ll"
+    instance = build(llvm_file, utilities=[ArgReaderPlugin()])
+
+    arg_provider = ArgProvider()
+    arg_provider.set_constant_args(
+        input_bool_array=[],
+        input_u64_array=[],
+        input_i64_array=[],
+        input_f64_array=[],
+    )
+
+    extractor = CircuitExtractor()
+
+    with arg_provider:
+        result = list(
+            list(r)
+            for r in instance.run_shots(
+                n_qubits=1, n_shots=1, simulator=Coinflip(), event_hook=extractor
+            )
+        )
+
+    trace = extractor.shots[0].get_trace()
+    json = trace.model_dump_json(indent=2)
+    snapshot.assert_match(json, "trace.json")
+
+    processed_trace = argreader_trace_pass(trace)
+    json = processed_trace.model_dump_json(indent=2)
+    snapshot.assert_match(json, "pass.json")

--- a/selene-ext/utilities/argreader/rust/lib.rs
+++ b/selene-ext/utilities/argreader/rust/lib.rs
@@ -346,6 +346,9 @@ pub unsafe extern "C" fn argreader_get_u64_array(key_ptr: *const u8, out_ptr: *m
                     values.len()
                 ));
             }
+            if len == 0 {
+                return;
+            }
             let u64_values: Vec<u64> = values.into_iter().map(|v| if v { 1 } else { 0 }).collect();
             unsafe {
                 std::ptr::copy_nonoverlapping(u64_values.as_ptr(), out_ptr, u64_values.len());
@@ -428,6 +431,9 @@ pub unsafe extern "C" fn argreader_get_i64_array(key_ptr: *const u8, out_ptr: *m
                     "Runtime argument '{key}' expects an array of {len} integers, but was provided a boolean array {values:?} of length {}",
                     values.len()
                 ));
+            }
+            if len == 0 {
+                return;
             }
             let i64_values: Vec<i64> = values.into_iter().map(|v| if v { 1 } else { 0 }).collect();
             unsafe {
@@ -515,6 +521,9 @@ pub unsafe extern "C" fn argreader_get_f64_array(key_ptr: *const u8, out_ptr: *m
                     "Runtime argument '{key}' expects an array of {len} floats, but was provided a boolean array {values:?} of length {}",
                     values.len()
                 ));
+            }
+            if len == 0 {
+                return;
             }
             let f64_values: Vec<f64> = values.into_iter().map(|v| if v { 1.0 } else { 0.0 }).collect();
             unsafe {

--- a/selene-ext/utilities/argreader/rust/lib.rs
+++ b/selene-ext/utilities/argreader/rust/lib.rs
@@ -339,6 +339,18 @@ pub unsafe extern "C" fn argreader_get_f64(key_ptr: *const u8) -> f64 {
 pub unsafe extern "C" fn argreader_get_u64_array(key_ptr: *const u8, out_ptr: *mut u64, len: u64) {
     let key = get_key(key_ptr);
     match unsafe { value_helper(&key) } {
+        InputRecord::BoolArray(values) => {
+            if values.len() != len as usize {
+                selene_panic(format!(
+                    "Runtime argument '{key}' expects an array of {len} unsigned integers, but was provided a boolean array {values:?} of length {}",
+                    values.len()
+                ));
+            }
+            let u64_values: Vec<u64> = values.into_iter().map(|v| if v { 1 } else { 0 }).collect();
+            unsafe {
+                std::ptr::copy_nonoverlapping(u64_values.as_ptr(), out_ptr, u64_values.len());
+            }
+        }
         InputRecord::U64Array(values) => {
             if values.len() != len as usize {
                 selene_panic(format!(
@@ -410,6 +422,18 @@ pub unsafe extern "C" fn argreader_get_u64_array(key_ptr: *const u8, out_ptr: *m
 pub unsafe extern "C" fn argreader_get_i64_array(key_ptr: *const u8, out_ptr: *mut i64, len: u64) {
     let key = get_key(key_ptr);
     match unsafe { value_helper(&key) } {
+        InputRecord::BoolArray(values) => {
+            if values.len() != len as usize {
+                selene_panic(format!(
+                    "Runtime argument '{key}' expects an array of {len} integers, but was provided a boolean array {values:?} of length {}",
+                    values.len()
+                ));
+            }
+            let i64_values: Vec<i64> = values.into_iter().map(|v| if v { 1 } else { 0 }).collect();
+            unsafe {
+                std::ptr::copy_nonoverlapping(i64_values.as_ptr(), out_ptr, i64_values.len());
+            }
+        }
         InputRecord::I64Array(values) => {
             if values.len() != len as usize {
                 let key = get_key(key_ptr);
@@ -485,6 +509,18 @@ pub unsafe extern "C" fn argreader_get_i64_array(key_ptr: *const u8, out_ptr: *m
 pub unsafe extern "C" fn argreader_get_f64_array(key_ptr: *const u8, out_ptr: *mut f64, len: u64) {
     let key = get_key(key_ptr);
     match unsafe { value_helper(&key) } {
+        InputRecord::BoolArray(values) => {
+            if values.len() != len as usize {
+                selene_panic(format!(
+                    "Runtime argument '{key}' expects an array of {len} floats, but was provided a boolean array {values:?} of length {}",
+                    values.len()
+                ));
+            }
+            let f64_values: Vec<f64> = values.into_iter().map(|v| if v { 1.0 } else { 0.0 }).collect();
+            unsafe {
+                std::ptr::copy_nonoverlapping(f64_values.as_ptr(), out_ptr, f64_values.len());
+            }
+        }
         InputRecord::F64Array(values) => {
             if values.len() != len as usize {
                 selene_panic(format!(


### PR DESCRIPTION
Previously, zero-length arrays were explicitly forbidden as arguments to ArgProvider, under the presumption that a zero-length input would not make any sense. However, there are some cases where it would be handy for generality, and as such this PR adds support for them.

It corrects a bug whereby bool arrays (which, as the first listed array type, are the default type for an empty array) would not be promoted to integer or floating point arrays.

Additionally, an argreader_trace_pass function is added, mapping a trace with OpaquePayloads with the argreader tag `0xA13613EADE130746`* to a KeyValuePairPayload that has the argument name and value provided directly.

_*note: opaque tags are just unique U64s, but if you blur your vision sufficiently it reads as 'ARGREADER0TAG'_