### PR TITLE
feat: Add dependency loader for interactive mode

### DIFF
--- a/selene-sim/python/selene_sim/interactive/_library.py
+++ b/selene-sim/python/selene_sim/interactive/_library.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import ctypes
+import os
+import re
+from pathlib import Path
+from typing import Callable, Protocol, TypeVar
+
+from selene_core import SeleneComponent
+
+
+T = TypeVar("T")
+_IS_WINDOWS = os.name == "nt"
+
+
+class _DirectoryHandle(Protocol):
+    def close(self) -> None: ...
+
+
+class LibrarySearch:
+    """Apply component library search directories to an in-process load.
+
+    When interactively loading dynamic libraries in python, one cannot
+    locally modify the environment in which dependencies are found, e.g.
+    LD_LIBRARY_PATH, DYLD_LIBRARY_PATH, or PATH. Instead, the environment
+    variables at launch of the python process itself are used. As plugins
+    may have dependencies, such as libcudart.so, we need a way to load them
+    in interactive sessions.
+    """
+
+    def __init__(self, search_dirs: list[Path]):
+        self.search_dirs = list(dict.fromkeys(Path(path) for path in search_dirs))
+        self._directory_handles: list[_DirectoryHandle] = []
+        self._dependencies: list[ctypes.CDLL] = []
+        self._loaded_dependency_paths: set[Path] = set()
+        self._loading: set[Path] = set()
+
+        if _IS_WINDOWS:
+            add_dll_directory = getattr(os, "add_dll_directory")
+            try:
+                for directory in self.search_dirs:
+                    self._directory_handles.append(add_dll_directory(directory))
+            except Exception:
+                self.close()
+                raise
+
+    def load(self, callback: Callable[[], T]) -> T:
+        """Run a library load, resolving missing POSIX dependencies on demand."""
+        while True:
+            try:
+                return callback()
+            except OSError as error:
+                dependency = self._find_missing_dependency(error)
+                if dependency is None:
+                    raise
+                self._load_dependency(dependency)
+
+    def _find_missing_dependency(self, error: OSError) -> Path | None:
+        if _IS_WINDOWS:
+            return None
+
+        message = str(error)
+        linux_match = re.search(
+            r"(?:^|: )([^/:\s]+): cannot open shared object file", message
+        )
+        macos_match = re.search(r"Library not loaded: (\S+)", message)
+        match = linux_match or macos_match
+        if match is None:
+            return None
+
+        library_name = Path(match.group(1)).name
+        for directory in self.search_dirs:
+            candidate = directory / library_name
+            if candidate.is_file():
+                return candidate
+        return None
+
+    def _load_dependency(self, dependency: Path) -> None:
+        dependency = dependency.resolve()
+        if dependency in self._loading or dependency in self._loaded_dependency_paths:
+            raise OSError(f"Cyclic dynamic library dependency involving {dependency}")
+
+        self._loading.add(dependency)
+        try:
+            library = self.load(
+                lambda: ctypes.CDLL(str(dependency), mode=ctypes.RTLD_GLOBAL)
+            )
+            self._dependencies.append(library)
+            self._loaded_dependency_paths.add(dependency)
+        finally:
+            self._loading.remove(dependency)
+
+    def close(self) -> None:
+        for handle in reversed(self._directory_handles):
+            handle.close()
+        self._directory_handles.clear()
+
+    def __del__(self):
+        self.close()
+
+
+def load_component_library(
+    component: SeleneComponent,
+) -> tuple[ctypes.CDLL, LibrarySearch]:
+    """Load a component library and retain everything needed by its loader."""
+    search = LibrarySearch(component.library_search_dirs)
+    try:
+        library = search.load(lambda: ctypes.CDLL(str(component.library_file)))
+    except Exception:
+        search.close()
+        raise
+    return library, search

--- a/selene-sim/python/selene_sim/interactive/full_stack.py
+++ b/selene-sim/python/selene_sim/interactive/full_stack.py
@@ -18,6 +18,8 @@ from selene_sim.instance import ShotSpec
 from selene_sim.result_handling import DataStream, ResultStream
 from selene_sim.result_handling.result_stream import StreamEntry
 
+from ._library import load_component_library
+
 
 PathLike = str | os.PathLike | bytes | bytearray
 
@@ -341,7 +343,12 @@ class InteractiveFullStack:
         self.runtime = runtime or SimpleRuntime()
         self.error_model = error_model or IdealErrorModel()
 
+        self._component_libraries = []
         try:
+            self._component_libraries = [
+                load_component_library(component)
+                for component in (self.simulator, self.error_model, self.runtime)
+            ]
             config_data = self._build_configuration(
                 n_qubits=n_qubits,
                 random_seed=random_seed,
@@ -392,6 +399,10 @@ class InteractiveFullStack:
         }
 
     def _teardown_environment(self):
+        if hasattr(self, "_component_libraries"):
+            for _, search in self._component_libraries:
+                search.close()
+            self._component_libraries.clear()
         if hasattr(self, "_tempdir") and self._tempdir is not None:
             self._tempdir.cleanup()
             self._tempdir = None
@@ -452,10 +463,14 @@ class InteractiveFullStack:
         return self._event_hook
 
     def __del__(self):
-        self._on_shot_end()
-        # Here we invoke selene_exit directly, as the call helpers request metadata to be pushed,
-        # which isn't valid after the instance has been destroyed
-        self._lib.selene_exit(self._instance).unwrap()
+        try:
+            if hasattr(self, "_instance") and bool(self._instance):
+                self._on_shot_end()
+                # Invoke selene_exit directly: the call helpers request metadata,
+                # which is not valid after the instance has been destroyed.
+                self._lib.selene_exit(self._instance).unwrap()
+        finally:
+            self._teardown_environment()
 
     def _invoke(self, func_name: str, *args):
         result = getattr(self._lib, func_name)(self._instance, *args)

--- a/selene-sim/python/selene_sim/interactive/runtime.py
+++ b/selene-sim/python/selene_sim/interactive/runtime.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import ctypes
+import random
+from dataclasses import dataclass
 
 from selene_core import Runtime
-import random
+
+from ._library import LibrarySearch
 
 
 class SeleneRuntimeInstance(ctypes.Structure):
@@ -365,7 +367,16 @@ GetRuntimeDescriptorFn = ctypes.CFUNCTYPE(ctypes.POINTER(RuntimePluginDescriptor
 
 class SeleneSimRuntimeLib(ctypes.CDLL):
     def __init__(self, runtime: Runtime) -> None:
-        super().__init__(str(runtime.library_file))
+        self._library_search = LibrarySearch(runtime.library_search_dirs)
+        try:
+            self._library_search.load(
+                lambda: super(SeleneSimRuntimeLib, self).__init__(
+                    str(runtime.library_file)
+                )
+            )
+        except Exception:
+            self._library_search.close()
+            raise
         self._configure_signatures()
 
     def _configure_signatures(self):

--- a/selene-sim/python/selene_sim/interactive/simulator.py
+++ b/selene-sim/python/selene_sim/interactive/simulator.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import ctypes
+import random
 from pathlib import Path
 
 from selene_core import Simulator
-import random
+
+from ._library import LibrarySearch
 
 
 class SeleneSimulatorInstance(ctypes.Structure):
@@ -100,7 +102,16 @@ GetSimulatorDescriptorFn = ctypes.CFUNCTYPE(ctypes.POINTER(SimulatorPluginDescri
 
 class SeleneSimSimulatorLib(ctypes.CDLL):
     def __init__(self, simulator: Simulator) -> None:
-        super().__init__(str(simulator.library_file))
+        self._library_search = LibrarySearch(simulator.library_search_dirs)
+        try:
+            self._library_search.load(
+                lambda: super(SeleneSimSimulatorLib, self).__init__(
+                    str(simulator.library_file)
+                )
+            )
+        except Exception:
+            self._library_search.close()
+            raise
         self._configure_signatures()
 
     def _configure_signatures(self):

--- a/selene-sim/python/tests/test_interactive.py
+++ b/selene-sim/python/tests/test_interactive.py
@@ -7,7 +7,13 @@ import tempfile
 
 import numpy as np
 
-from selene_sim import DepolarizingErrorModel, Quest, SoftRZRuntime, SimpleRuntime
+from selene_sim import (
+    DepolarizingErrorModel,
+    Quest,
+    SimpleRuntime,
+    SoftRZRuntime,
+    Stim,
+)
 from selene_sim.interactive import (
     InteractiveFullStack,
     InteractiveSimulator,
@@ -238,6 +244,16 @@ def test_interactive_simulator():
     assert sim.measure(1)
     assert sim.measure(2)
     assert sim.measure(3)
+
+
+def test_interactive_stim_library_search_dirs():
+    simulator = InteractiveSimulator(simulator=Stim(), n_qubits=1)
+    assert not simulator.measure(0)
+
+    full_stack = InteractiveFullStack(simulator=Stim(), n_qubits=1)
+    qubit = full_stack.qalloc()
+    full_stack.reset(qubit)
+    assert not full_stack.measure(qubit)
 
 
 def test_interactive_runtime_simple():

--- a/selene-sim/python/tests/test_interactive_library_search.py
+++ b/selene-sim/python/tests/test_interactive_library_search.py
@@ -1,0 +1,65 @@
+import ctypes
+import os
+from pathlib import Path
+
+import pytest
+
+from selene_sim.interactive import _library
+from selene_sim.interactive._library import LibrarySearch
+
+
+def test_posix_library_search_loads_a_missing_dependency(monkeypatch, tmp_path):
+    if os.name == "nt":
+        pytest.skip("POSIX dependency resolution test")
+
+    dependency = tmp_path / "libdependency.so"
+    dependency.touch()
+    attempts = 0
+    loaded = []
+
+    def load_plugin():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError(
+                "libdependency.so: cannot open shared object file: "
+                "No such file or directory"
+            )
+        return "plugin"
+
+    def load_dependency(path, *, mode):
+        loaded.append((Path(path), mode))
+        return object()
+
+    monkeypatch.setattr(ctypes, "CDLL", load_dependency)
+
+    search = LibrarySearch([tmp_path])
+    assert search.load(load_plugin) == "plugin"
+    assert loaded == [(dependency, ctypes.RTLD_GLOBAL)]
+
+
+def test_windows_library_search_keeps_directory_handles_open(monkeypatch, tmp_path):
+    class Handle:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    handles = []
+
+    def add_dll_directory(path):
+        assert path == tmp_path
+        handle = Handle()
+        handles.append(handle)
+        return handle
+
+    monkeypatch.setattr(_library, "_IS_WINDOWS", True)
+    monkeypatch.setattr(os, "add_dll_directory", add_dll_directory, raising=False)
+
+    search = LibrarySearch([tmp_path])
+    assert len(handles) == 1
+    assert not handles[0].closed
+
+    search.close()
+    assert handles[0].closed


### PR DESCRIPTION
Adds dependency loading fallbacks for interactive mode so that `library_search_dirs` can be taken into account. As tested locally on a plugin with dynamic dependencies on external libraries.